### PR TITLE
Improve PLR functionality. Other small improvements

### DIFF
--- a/config/MMB Cubic (with Silent Kit)/macros.cfg
+++ b/config/MMB Cubic (with Silent Kit)/macros.cfg
@@ -1187,7 +1187,7 @@ gcode:
     SET_VELOCITY_LIMIT VELOCITY={max_velocity} ACCEL={max_accel} MINIMUM_CRUISE_RATIO={minimum_cruise_ratio} SQUARE_CORNER_VELOCITY={square_corner_velocity}
     M220 S{speed_factor * 100}
     M221 S{extrude_factor * 100}
-    {% set fan_speed = fan_speed * 255 / 0.90 %}
+    {% set fan_speed = fan_speed * 255 / 0.5 %}
     M106 S{fan_speed}
     POWER_LOSS_RESTART_PRINT FILENAME='{last_file}' FILEPOSITION={file_position} PRINT_DURATION={print_duration} FILAMENT_USED={filament_used}
   {% else %}

--- a/config/MMB Cubic (with Silent Kit)/macros.cfg
+++ b/config/MMB Cubic (with Silent Kit)/macros.cfg
@@ -30,7 +30,6 @@ gcode:
     M82
     G28
     M204 S200
-    SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
     {% if X_MIN > 100 or X_MAX > 100 or Y_MIN > 100 or Y_MAX > 100 or X_MIN < -100 or X_MAX < -100 or Y_MIN < -100 or Y_MAX < -100 %}
       M140 S{BED_TEMP} A1 B1
     {% else %}
@@ -64,7 +63,6 @@ gcode:
     M82
     G28
     M204 S200
-    SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
     M140 S{BED_TEMP}
     M190 S{BED_TEMP}
     M104 S140
@@ -90,7 +88,6 @@ gcode:
     M82
     G28
     M204 S200
-    SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
     M140 S{BED_TEMP}
     M190 S{BED_TEMP}
     M104 S140
@@ -113,7 +110,6 @@ gcode:
     G90
     M82
     G28
-    SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
     BED_MESH_PROFILE LOAD=default
     {% if X_MIN > 100 or X_MAX > 100 or Y_MIN > 100 or Y_MAX > 100 or X_MIN < -100 or X_MAX < -100 or Y_MIN < -100 or Y_MAX < -100 %}
       M140 S{BED_TEMP} A1 B1
@@ -1110,10 +1106,11 @@ description: Start G-Codes for Power Loss
 gcode:
   _RELAY_ON
   _CLEAR_POWER_LOSS_PARAMS
-  SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
-  SET_VELOCITY_LIMIT ACCEL=40000
-  SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY=5
-  SET_VELOCITY_LIMIT ACCEL_TO_DECEL=6000
+  SET_TMC_CURRENT STEPPER=extruder CURRENT={printer.configfile.settings['tmc5160 extruder'].run_current}
+  SET_VELOCITY_LIMIT VELOCITY={printer.configfile.settings.printer.max_velocity}
+  SET_VELOCITY_LIMIT ACCEL={printer.configfile.settings.printer.max_accel}
+  SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY={printer.configfile.settings.printer.square_corner_velocity}
+  SET_VELOCITY_LIMIT MINIMUM_CRUISE_RATIO={printer.configfile.settings.printer.minimum_cruise_ratio}
   CLEAR_PAUSE
   _NEOPIXELS_WHITE
   _SCREEN_LED_ON R=0 O=0 W=1
@@ -1126,7 +1123,7 @@ description: Resume G-Codes for Power Loss
 gcode:
   _RELAY_ON
   _CLEAR_POWER_LOSS_PARAMS
-  SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
+  SET_TMC_CURRENT STEPPER=extruder CURRENT={printer.configfile.settings['tmc5160 extruder'].run_current}
   CLEAR_PAUSE
   _NEOPIXELS_WHITE
   _SCREEN_LED_ON R=0 O=0 W=1

--- a/config/MMB Cubic (with Silent Kit)/macros.cfg
+++ b/config/MMB Cubic (with Silent Kit)/macros.cfg
@@ -205,6 +205,7 @@ variable_nozzle_temp: 0
 variable_m600_state: 0
 gcode:
   {% if printer.print_stats.state == "paused" %}
+    M106 S0
     M109 S{nozzle_temp}
     {% if 'VELOCITY' in params|upper %}
       {% set get_params = ('VELOCITY=' + params.VELOCITY) %}

--- a/config/MMB Cubic (with Silent Kit)/macros.cfg
+++ b/config/MMB Cubic (with Silent Kit)/macros.cfg
@@ -706,7 +706,7 @@ gcode:
 [gcode_macro CALIBRATION_PID_HOTEND]
 description: Start Hotend PID Calibration
 gcode:
-  {% set HOTEND_TEMP=params.HOTEND_TEMP|default(350)|float %}
+  {% set HOTEND_TEMP=params.HOTEND_TEMP|default(250)|float %}
   {% if printer.idle_timeout.state == "Printing" %}
     RESPOND TYPE=error MSG="This macro cannot be used while printing!"
   {% else %}

--- a/config/MMB Cubic (with Silent Kit)/macros.cfg
+++ b/config/MMB Cubic (with Silent Kit)/macros.cfg
@@ -126,7 +126,6 @@ gcode:
       M190 S{BED_TEMP} A1 B0
     {% endif %}
     M104 S{HOTEND_TEMP} T0
-    M107 T0
     G1 Z150 F6000
     G1 X-160 Y0 Z1 F4000
     M109 S{HOTEND_TEMP} T0
@@ -164,25 +163,7 @@ description: Pause Print
 rename_existing: PAUSE_BASE
 gcode:
   {% if printer.print_stats.state == "printing" %}
-    {% set file_position = printer.virtual_sdcard.file_position %}
-    SAVE_VARIABLE VARIABLE=file_position VALUE={file_position}
-    {% set e_pos = printer.gcode_move.gcode_position.e %}
-    SAVE_VARIABLE VARIABLE=e_pos VALUE={e_pos}
-    {% set x_pos = printer.gcode_move.gcode_position.x %}
-    SAVE_VARIABLE VARIABLE=x_pos VALUE={x_pos}
-    {% set y_pos = printer.gcode_move.gcode_position.y %}
-    SAVE_VARIABLE VARIABLE=y_pos VALUE={y_pos}
-    {% set z_pos = printer.gcode_move.gcode_position.z %}
-    SAVE_VARIABLE VARIABLE=z_pos VALUE={z_pos}
-    {% set print_duration = printer.print_stats.print_duration %}
-    SAVE_VARIABLE VARIABLE=print_duration VALUE={print_duration}
-    {% set fan_speed = printer.fan.speed|float %}
-    SAVE_VARIABLE VARIABLE=fan_speed VALUE={fan_speed}
-    {% set nozzle_temp = printer.extruder.target|float %}
-    SAVE_VARIABLE VARIABLE=nozzle_temp VALUE={nozzle_temp}
-    {% set bed_temp = printer.heater_bed.target|float %}
-    SAVE_VARIABLE VARIABLE=bed_temp VALUE={bed_temp}
-    SAVE_VARIABLE VARIABLE=was_interrupted VALUE=True    
+    _SAVE_POWER_LOSS_PARAMS
     {% set x = params.X|default(0) %}
     {% set y = params.Y|default(-140) %}
     {% set z = params.Z|default(10)|float %}
@@ -198,7 +179,7 @@ gcode:
     {% else %}
       {% set z_safe = max_z %}
     {% endif %}
-	{% set fan_speed = printer.fan.speed|float %}
+    {% set fan_speed = printer.fan.speed|float %}
     SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=fan_speed VALUE={fan_speed}
     PAUSE_BASE
     G91
@@ -213,11 +194,11 @@ gcode:
     {% else %}
       RESPOND TYPE=error MSG="Printer not homed!"
     {% endif %}
-	{% set nozzle_temp = printer.extruder.target|float %}
+    {% set nozzle_temp = printer.extruder.target|float %}
     SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=nozzle_temp VALUE={nozzle_temp}
     M104 S90
-	M106 S128
-	M400
+    M106 S128
+    M400
   {% endif %}
 
 [gcode_macro RESUME]
@@ -244,7 +225,7 @@ gcode:
       G90
       M400
     {% endif %}
-    SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
+    _CLEAR_POWER_LOSS_PARAMS
     {% set fan_speed = fan_speed * 255 / 0.5 %}
     M106 S{fan_speed}
     {% if printer['gcode_macro RESUME'].m600_state == 1 %}
@@ -262,7 +243,7 @@ gcode:
 description: Cancel Print
 rename_existing: CANCEL_PRINT_BASE
 gcode:
-  SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
+  _CLEAR_POWER_LOSS_PARAMS
   {% set x = params.X|default(0) %}
   {% set y = params.Y|default(0) %}
   {% set z = params.Z|default(10)|float %}
@@ -307,6 +288,7 @@ gcode:
 [gcode_macro M600]
 description: Filament Change
 gcode:
+  _SAVE_POWER_LOSS_PARAMS
   {% set x = params.X|default(0) %}
   {% set y = params.Y|default(-140) %}
   {% set z = params.Z|default(10)|float %}
@@ -545,6 +527,7 @@ gcode:
   SET_PIN PIN=_motor_cali_a VALUE=0
   SET_PIN PIN=_motor_cali_b VALUE=0
   SET_PIN PIN=_motor_cali_c VALUE=0
+  G4 P1000
 
 [gcode_macro _CALIBRATION_MOTORS_DATA]
 description: Motors Calibration
@@ -1126,14 +1109,7 @@ gcode:
 description: Start G-Codes for Power Loss
 gcode:
   _RELAY_ON
-  {% set sd_filename = printer.virtual_sdcard.file_path|string %}
-  SAVE_VARIABLE VARIABLE=sd_filename VALUE='"{sd_filename}"'
-  SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
-  SAVE_VARIABLE VARIABLE=file_position VALUE=0
-  SAVE_VARIABLE VARIABLE=x_pos VALUE=0.0
-  SAVE_VARIABLE VARIABLE=y_pos VALUE=0.0
-  SAVE_VARIABLE VARIABLE=z_pos VALUE=0.0
-  SAVE_VARIABLE VARIABLE=e_pos VALUE=0.0
+  _CLEAR_POWER_LOSS_PARAMS
   SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
   SET_VELOCITY_LIMIT ACCEL=40000
   SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY=5
@@ -1148,19 +1124,9 @@ gcode:
 [gcode_macro _START_PRINT_RESUME]
 description: Resume G-Codes for Power Loss
 gcode:
-  {% set sd_filename = printer.virtual_sdcard.file_path|string %}
-  SAVE_VARIABLE VARIABLE=sd_filename VALUE='"{sd_filename}"'
-  SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
-  {% set file_position = printer.save_variables.variables.file_position %}
-  SAVE_VARIABLE VARIABLE=file_position VALUE='"{file_position}"'
-  {% set x_pos = printer.save_variables.variables.x_pos %}
-  SAVE_VARIABLE VARIABLE=x_pos VALUE='"{x_pos}"'
-  {% set y_pos = printer.save_variables.variables.y_pos %}
-  SAVE_VARIABLE VARIABLE=y_pos VALUE='"{y_pos}"'
-  {% set z_pos = printer.save_variables.variables.z_pos %}
-  SAVE_VARIABLE VARIABLE=z_pos VALUE='"{z_pos}"'
-  {% set e_pos = printer.save_variables.variables.e_pos %}
-  SAVE_VARIABLE VARIABLE=e_pos VALUE='"{e_pos}"'
+  _RELAY_ON
+  _CLEAR_POWER_LOSS_PARAMS
+  SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
   CLEAR_PAUSE
   _NEOPIXELS_WHITE
   _SCREEN_LED_ON R=0 O=0 W=1
@@ -1169,7 +1135,7 @@ gcode:
 [gcode_macro _END_PRINT]
 description: End G-Codes for Power Loss
 gcode:
-  SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
+  _CLEAR_POWER_LOSS_PARAMS
   SET_STEPPER_ENABLE STEPPER=extruder ENABLE=0
   M106 S128
   UPDATE_DELAYED_GCODE ID=WAIT_COOLING DURATION=60
@@ -1178,34 +1144,104 @@ gcode:
 description: Resume Print from Power Loss
 gcode:
   RESPOND TYPE=command MSG=action:prompt_end
-  {% set file_position = printer.save_variables.variables.file_position %}
-  {% set e_pos = printer.save_variables.variables.e_pos %}
-  {% set x_pos = printer.save_variables.variables.x_pos %}
-  {% set y_pos = printer.save_variables.variables.y_pos %}
-  {% set z_pos = printer.save_variables.variables.z_pos %}
-  {% set last_file = params.GCODE_FILE|default(printer.save_variables.variables.sd_filename)|string %}
-  {% set print_duration = printer.save_variables.variables.print_duration %}
-  {% set fan_speed = printer.save_variables.variables.fan_speed %}
-  {% set nozzle_temp = printer.save_variables.variables.nozzle_temp %}
-  {% set bed_temp = printer.save_variables.variables.bed_temp %}
-  G28
-  SAVE_VARIABLE VARIABLE=plr_flag VALUE=True
-  _SCREEN_LED_ON R=1 O=1 W=0
-  _NEOPIXELS_BED
-  M104 S{nozzle_temp}
-  M140 S{bed_temp}
-  M109 S{nozzle_temp}
-  M190 S{bed_temp}
-  _NEOPIXELS_WHITE
-  _SCREEN_LED_ON R=0 O=0 W=1
-  {% set fan_speed = fan_speed * 255 / 0.5 %}
-  M106 S{fan_speed}
-  G90
-  G92 E{e_pos}
-  M83
-  G1 X{x_pos} Y{y_pos} Z{z_pos}
-  POWER_LOSS_RESTART_PRINT FILENAME='{last_file}' FILEPOSITION={file_position} PRINT_DURATION={print_duration}
+  {% if printer.save_variables.variables.was_interrupted %}
+    {% set file_position = printer.save_variables.variables.file_position %}
+    {% set absolute_extrude = printer.save_variables.variables.absolute_extrude %}
+    {% set e_pos = printer.save_variables.variables.e_pos %}
+    {% set x_pos = printer.save_variables.variables.x_pos %}
+    {% set y_pos = printer.save_variables.variables.y_pos %}
+    {% set z_pos = printer.save_variables.variables.z_pos %}
+    {% set last_file = params.GCODE_FILE|default(printer.save_variables.variables.sd_filename)|string %}
+    {% set print_duration = printer.save_variables.variables.print_duration %}
+    {% set filament_used = printer.save_variables.variables.filament_used %}
+    {% set nozzle_temp = printer.save_variables.variables.nozzle_temp %}
+    {% set bed_temp = printer.save_variables.variables.bed_temp %}
+    {% set bed_temp_out = printer.save_variables.variables.bed_temp_out %}
+    {% set chamber_fan_speed = printer.save_variables.variables.chamber_fan_speed %}  
+    {% set max_velocity = printer.save_variables.variables.max_velocity %}
+    {% set max_accel = printer.save_variables.variables.max_accel %}
+    {% set minimum_cruise_ratio = printer.save_variables.variables.minimum_cruise_ratio %}
+    {% set square_corner_velocity = printer.save_variables.variables.square_corner_velocity %}
+    {% set speed_factor = printer.save_variables.variables.speed_factor %}
+    {% set extrude_factor = printer.save_variables.variables.extrude_factor %}
+    {% set fan_speed = printer.save_variables.variables.fan_speed %}
+    G28
+    _SCREEN_LED_ON R=1 O=1 W=0
+    _NEOPIXELS_BED
+    M104 S{nozzle_temp}
+    M140 S{bed_temp} A1 B0
+    SET_HEATER_TEMPERATURE HEATER=heater_bed_2 TARGET={bed_temp_out} WAIT=0
+    M109 S{nozzle_temp}
+    M190 S{bed_temp} A1 B0
+    SET_HEATER_TEMPERATURE HEATER=heater_bed_2 TARGET={bed_temp_out} WAIT=1
+    _SCREEN_LED_ON R=0 O=1 W=1
+    SET_FAN_SPEED FAN=chamber_fan SPEED={chamber_fan_speed}
+    G90
+    G92 E{e_pos}
+    {% if absolute_extrude %}
+      M82
+    {% else %}
+      M83
+    {% endif%}
+    G1 X{x_pos} Y{y_pos} Z{z_pos} E1 F2000
+    SET_VELOCITY_LIMIT VELOCITY={max_velocity} ACCEL={max_accel} MINIMUM_CRUISE_RATIO={minimum_cruise_ratio} SQUARE_CORNER_VELOCITY={square_corner_velocity}
+    M220 S{speed_factor * 100}
+    M221 S{extrude_factor * 100}
+    {% set fan_speed = fan_speed * 255 / 0.90 %}
+    M106 S{fan_speed}
+    POWER_LOSS_RESTART_PRINT FILENAME='{last_file}' FILEPOSITION={file_position} PRINT_DURATION={print_duration} FILAMENT_USED={filament_used}
+  {% else %}
+    RESPOND MSG="No previous state saved!"
+  {% endif%}
 
+[gcode_macro _SAVE_POWER_LOSS_PARAMS]
+description: Save parameters for Power Loss Recovery
+gcode:
+    SAVE_VARIABLE VARIABLE=sd_filename VALUE='"{printer.virtual_sdcard.file_path|string}"'
+    SAVE_VARIABLE VARIABLE=file_position VALUE={printer.virtual_sdcard.file_position}
+    SAVE_VARIABLE VARIABLE=absolute_extrude VALUE={printer.gcode_move.absolute_extrude}
+    SAVE_VARIABLE VARIABLE=e_pos VALUE={printer.gcode_move.gcode_position.e}
+    SAVE_VARIABLE VARIABLE=x_pos VALUE={printer.gcode_move.gcode_position.x}
+    SAVE_VARIABLE VARIABLE=y_pos VALUE={printer.gcode_move.gcode_position.y}
+    SAVE_VARIABLE VARIABLE=z_pos VALUE={printer.gcode_move.gcode_position.z}
+    SAVE_VARIABLE VARIABLE=speed_factor VALUE={printer.gcode_move.speed_factor}
+    SAVE_VARIABLE VARIABLE=extrude_factor VALUE={printer.gcode_move.extrude_factor}
+    SAVE_VARIABLE VARIABLE=print_duration VALUE={printer.print_stats.print_duration}
+    SAVE_VARIABLE VARIABLE=filament_used VALUE={printer.print_stats.filament_used}
+    SAVE_VARIABLE VARIABLE=fan_speed VALUE={printer.fan.speed|float}
+    SAVE_VARIABLE VARIABLE=nozzle_temp VALUE={printer.extruder.target|float}
+    SAVE_VARIABLE VARIABLE=bed_temp VALUE={printer.heater_bed.target|float}
+    SAVE_VARIABLE VARIABLE=bed_temp_out VALUE={printer["heater_generic heater_bed_2"].target|float}
+    SAVE_VARIABLE VARIABLE=chamber_fan_speed VALUE={printer["fan_generic chamber_fan"].speed|float}
+    SAVE_VARIABLE VARIABLE=max_velocity VALUE={printer.toolhead.max_velocity}
+    SAVE_VARIABLE VARIABLE=max_accel VALUE={printer.toolhead.max_accel}
+    SAVE_VARIABLE VARIABLE=minimum_cruise_ratio VALUE={printer.toolhead.minimum_cruise_ratio}
+    SAVE_VARIABLE VARIABLE=square_corner_velocity VALUE={printer.toolhead.square_corner_velocity}
+    SAVE_VARIABLE VARIABLE=was_interrupted VALUE=True
+
+[gcode_macro _CLEAR_POWER_LOSS_PARAMS]
+description: Clear parameters for Power Loss Recovery
+gcode:
+    SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
+    SAVE_VARIABLE VARIABLE=file_position VALUE=0
+    SAVE_VARIABLE VARIABLE=absolute_extrude VALUE=False
+    SAVE_VARIABLE VARIABLE=e_pos VALUE=0.0
+    SAVE_VARIABLE VARIABLE=x_pos VALUE=0.0
+    SAVE_VARIABLE VARIABLE=y_pos VALUE=0.0
+    SAVE_VARIABLE VARIABLE=z_pos VALUE=0.0
+    SAVE_VARIABLE VARIABLE=speed_factor VALUE=1.0
+    SAVE_VARIABLE VARIABLE=extrude_factor VALUE=1.0
+    SAVE_VARIABLE VARIABLE=print_duration VALUE=0.0
+    SAVE_VARIABLE VARIABLE=filament_used VALUE=0.0
+    SAVE_VARIABLE VARIABLE=fan_speed VALUE=0.0
+    SAVE_VARIABLE VARIABLE=nozzle_temp VALUE=0
+    SAVE_VARIABLE VARIABLE=bed_temp VALUE=0
+    SAVE_VARIABLE VARIABLE=bed_temp_out VALUE=0
+    SAVE_VARIABLE VARIABLE=chamber_fan_speed VALUE=0.0
+    SAVE_VARIABLE VARIABLE=max_velocity VALUE={printer.toolhead.max_velocity}
+    SAVE_VARIABLE VARIABLE=max_accel VALUE={printer.toolhead.max_accel}
+    SAVE_VARIABLE VARIABLE=minimum_cruise_ratio VALUE={printer.toolhead.minimum_cruise_ratio}
+    SAVE_VARIABLE VARIABLE=square_corner_velocity VALUE={printer.toolhead.square_corner_velocity}
 
 ##################################################
 # Gcode Offsets Management
@@ -1432,6 +1468,7 @@ gcode:
     RESPOND MSG="Resonances Calibration done!"
   {% endif %}
   {% if printer.save_variables.variables.was_interrupted %}
+    G4 P5000
     RESPOND TYPE=command MSG="action:prompt_begin Power Loss Recovery"
     RESPOND TYPE=command MSG="action:prompt_text A power loss has occurred!"
     RESPOND TYPE=command MSG="action:prompt_text Do you want to resume current print?"
@@ -1439,13 +1476,12 @@ gcode:
     RESPOND TYPE=command MSG="action:prompt_footer_button RESUME PRINT|RESUME_PRINT_AFTER_PLR|primary"
     RESPOND TYPE=command MSG="action:prompt_show"
   {% endif %}
-  SAVE_VARIABLE VARIABLE=plr_flag VALUE=False
 
 [gcode_macro _CANCEL_PLR]
 description: Cancel Power Loss Recovery
 gcode:
   RESPOND TYPE=command MSG=action:prompt_end
-  SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
+  _CLEAR_POWER_LOSS_PARAMS
 
 [gcode_shell_command Screenshot]
 command: bash /home/pi/flsun-os/macros/screenshot.sh

--- a/config/MMB Cubic (with Silent Kit)/macros.cfg
+++ b/config/MMB Cubic (with Silent Kit)/macros.cfg
@@ -1256,26 +1256,36 @@ gcode:
   {% else %}
     {% set offsets = {'x': None,'y': None,'z': None} %}
   {% endif %}
-  {% set ns = namespace(offsets={'x': offsets.x,'y': offsets.y,'z': offsets.z}) %}
-  {%if 'X' in params %}{% set null = ns.offsets.update({'x': params.X}) %}{% endif %}
-  {%if 'Y' in params %}{% set null = ns.offsets.update({'y': params.Y}) %}{% endif %}
-  {%if 'Z' in params %}{% set null = ns.offsets.update({'z': params.Z}) %}{% endif %}
-  {%if 'Z_ADJUST' in params %}
-    {%if ns.offsets.z == None %}
-      {% set null = ns.offsets.update({'z': 0}) %}
+  {%if 'X' in params %}{% set null = offsets.update({'x': params.X}) %}{% endif %}
+  {%if 'Y' in params %}{% set null = offsets.update({'y': params.Y}) %}{% endif %}
+  {%if 'Z' in params %}{% set null = offsets.update({'z': params.Z}) %}{% endif %}
+  {%if 'X_ADJUST' in params %}
+    {%if offsets.x == None %}
+      {% set null = offsets.update({'x': 0}) %}
     {% endif %}
-    {% set null = ns.offsets.update({'z': (ns.offsets.z | float) + (params.Z_ADJUST | float)}) %}
+    {% set null = offsets.update({'x': (offsets.x | float) + (params.X_ADJUST | float)}) %}
+  {% endif %}
+  {%if 'Y_ADJUST' in params %}
+    {%if offsets.y == None %}
+      {% set null = offsets.update({'y': 0}) %}
+    {% endif %}
+    {% set null = offsets.update({'y': (offsets.y | float) + (params.Y_ADJUST | float)}) %}
+  {% endif %}
+  {%if 'Z_ADJUST' in params %}
+    {%if offsets.z == None %}
+      {% set null = offsets.update({'z': 0}) %}
+    {% endif %}
+    {% set null = offsets.update({'z': (offsets.z | float) + (params.Z_ADJUST | float)}) %}
   {% endif %}
   _SET_GCODE_OFFSET {% for p in params %}{'%s=%s '% (p, params[p])}{% endfor %}
-  SAVE_VARIABLE VARIABLE=gcode_offsets VALUE="{ns.offsets}"
+  SAVE_VARIABLE VARIABLE=gcode_offsets VALUE="{offsets}"
 
 [gcode_macro Z_OFFSET_APPLY_ENDSTOP]
 description: Apply Gcode Offsets to Endstops
 rename_existing: _Z_OFFSET_APPLY_ENDSTOP
 gcode:
   _Z_OFFSET_APPLY_ENDSTOP
-  {% set offsets = {'x': None,'y': None,'z': 0} %}
-  SAVE_VARIABLE VARIABLE=gcode_offsets VALUE="{offsets}"
+  SET_GCODE_OFFSET Z=0
 
 
 ##################################################

--- a/config/MMB Cubic (with Silent Kit)/printer.cfg
+++ b/config/MMB Cubic (with Silent Kit)/printer.cfg
@@ -149,7 +149,7 @@ spi_software_sclk_pin: PA6
 spi_software_mosi_pin: PA5
 spi_software_miso_pin: PC4
 sense_resistor: 0.0375
-run_current: 1.2
+run_current: 0.8
 interpolate: True
 stealthchop_threshold: 0
 

--- a/config/MMB Cubic (with Silent Kit)/printer.cfg
+++ b/config/MMB Cubic (with Silent Kit)/printer.cfg
@@ -240,7 +240,7 @@ max_power: 0.5
 [heater_fan heat_sink_fan]
 pin: PA2
 heater_temp: 50.0
-shutdown_speed: 0
+shutdown_speed: 1
 
 [heater_fan motherboard_fan]
 pin: PB5
@@ -257,7 +257,7 @@ pin: PB4
 [heater_fan drying_box_fan]
 pin: PA8
 heater: drying_box
-shutdown_speed: 0
+shutdown_speed: 1
 
 [temperature_sensor _drying_box_temp]
 sensor_type: temperature_host
@@ -430,39 +430,27 @@ switch_pin: PD3
 event_delay: 0.01
 pause_delay: 0.01
 runout_gcode:
-  RESPOND TYPE=error MSG="Power loss detected!"
   _SCREEN_LED_ON R=1 O=0 W=0
   {% if printer.print_stats.state == "printing" %}
-    {% set file_position = printer.virtual_sdcard.file_position %}
-    SAVE_VARIABLE VARIABLE=file_position VALUE={file_position}
-    {% set e_pos = printer.gcode_move.gcode_position.e %}
-    SAVE_VARIABLE VARIABLE=e_pos VALUE={e_pos}
-    {% set x_pos = printer.gcode_move.gcode_position.x %}
-    SAVE_VARIABLE VARIABLE=x_pos VALUE={x_pos}
-    {% set y_pos = printer.gcode_move.gcode_position.y %}
-    SAVE_VARIABLE VARIABLE=y_pos VALUE={y_pos}
-    {% set z_pos = printer.gcode_move.gcode_position.z %}
-    SAVE_VARIABLE VARIABLE=z_pos VALUE={z_pos}
-    {% set print_duration = printer.print_stats.print_duration %}
-    SAVE_VARIABLE VARIABLE=print_duration VALUE={print_duration}
-    {% set fan_speed = printer.fan.speed|float %}
-    SAVE_VARIABLE VARIABLE=fan_speed VALUE={fan_speed}
-    {% set nozzle_temp = printer.extruder.target|float %}
-    SAVE_VARIABLE VARIABLE=nozzle_temp VALUE={nozzle_temp}
-    {% set bed_temp = printer.heater_bed.target|float %}
-    SAVE_VARIABLE VARIABLE=bed_temp VALUE={bed_temp}
-    SAVE_VARIABLE VARIABLE=was_interrupted VALUE=True
+    _SAVE_POWER_LOSS_PARAMS
+    FAN_STOP
+    TURN_OFF_HEATERS
+    SET_FAN_SPEED FAN=chamber_fan SPEED=0
+    _NEOPIXELS_OFF
+    RESPOND TYPE=error MSG="Power loss detected!"
+    M400
+    SET_STEPPER_ENABLE STEPPER=extruder ENABLE=0
     STEPPER_STOP
     _SHUTDOWN
     G4 P5000
   {% endif %}
 insert_gcode:
   {% if printer.print_stats.state != "printing" %}
-    RESPOND TYPE=error MSG="Power loss detected! Shutting down."
     _SCREEN_LED_ON R=1 O=0 W=0
+    RESPOND TYPE=error MSG="Power loss detected! Shutting down."
+    FAN_STOP
     TURN_OFF_HEATERS
     SET_FAN_SPEED FAN=chamber_fan SPEED=0
-    M106.1 S0 
     _SHUTDOWN
     G4 P5000
   {% endif %}

--- a/config/MMB Cubic (without Silent Kit)/macros.cfg
+++ b/config/MMB Cubic (without Silent Kit)/macros.cfg
@@ -126,7 +126,6 @@ gcode:
       M190 S{BED_TEMP} A1 B0
     {% endif %}
     M104 S{HOTEND_TEMP} T0
-    M107 T0
     G1 Z150 F6000
     G1 X-160 Y0 Z1 F4000
     M109 S{HOTEND_TEMP} T0
@@ -164,25 +163,7 @@ description: Pause Print
 rename_existing: PAUSE_BASE
 gcode:
   {% if printer.print_stats.state == "printing" %}
-    {% set file_position = printer.virtual_sdcard.file_position %}
-    SAVE_VARIABLE VARIABLE=file_position VALUE={file_position}
-    {% set e_pos = printer.gcode_move.gcode_position.e %}
-    SAVE_VARIABLE VARIABLE=e_pos VALUE={e_pos}
-    {% set x_pos = printer.gcode_move.gcode_position.x %}
-    SAVE_VARIABLE VARIABLE=x_pos VALUE={x_pos}
-    {% set y_pos = printer.gcode_move.gcode_position.y %}
-    SAVE_VARIABLE VARIABLE=y_pos VALUE={y_pos}
-    {% set z_pos = printer.gcode_move.gcode_position.z %}
-    SAVE_VARIABLE VARIABLE=z_pos VALUE={z_pos}
-    {% set print_duration = printer.print_stats.print_duration %}
-    SAVE_VARIABLE VARIABLE=print_duration VALUE={print_duration}
-    {% set fan_speed = printer.fan.speed|float %}
-    SAVE_VARIABLE VARIABLE=fan_speed VALUE={fan_speed}
-    {% set nozzle_temp = printer.extruder.target|float %}
-    SAVE_VARIABLE VARIABLE=nozzle_temp VALUE={nozzle_temp}
-    {% set bed_temp = printer.heater_bed.target|float %}
-    SAVE_VARIABLE VARIABLE=bed_temp VALUE={bed_temp}
-    SAVE_VARIABLE VARIABLE=was_interrupted VALUE=True    
+    _SAVE_POWER_LOSS_PARAMS
     {% set x = params.X|default(0) %}
     {% set y = params.Y|default(-140) %}
     {% set z = params.Z|default(10)|float %}
@@ -198,7 +179,7 @@ gcode:
     {% else %}
       {% set z_safe = max_z %}
     {% endif %}
-	{% set fan_speed = printer.fan.speed|float %}
+    {% set fan_speed = printer.fan.speed|float %}
     SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=fan_speed VALUE={fan_speed}
     PAUSE_BASE
     G91
@@ -213,11 +194,11 @@ gcode:
     {% else %}
       RESPOND TYPE=error MSG="Printer not homed!"
     {% endif %}
-	{% set nozzle_temp = printer.extruder.target|float %}
+    {% set nozzle_temp = printer.extruder.target|float %}
     SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=nozzle_temp VALUE={nozzle_temp}
     M104 S90
-	M106 S128
-	M400
+    M106 S128
+    M400
   {% endif %}
 
 [gcode_macro RESUME]
@@ -244,7 +225,7 @@ gcode:
       G90
       M400
     {% endif %}
-    SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
+    _CLEAR_POWER_LOSS_PARAMS
     {% set fan_speed = fan_speed * 255 / 0.90 %}
     M106 S{fan_speed}
     {% if printer['gcode_macro RESUME'].m600_state == 1 %}
@@ -262,7 +243,7 @@ gcode:
 description: Cancel Print
 rename_existing: CANCEL_PRINT_BASE
 gcode:
-  SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
+  _CLEAR_POWER_LOSS_PARAMS
   {% set x = params.X|default(0) %}
   {% set y = params.Y|default(0) %}
   {% set z = params.Z|default(10)|float %}
@@ -307,6 +288,7 @@ gcode:
 [gcode_macro M600]
 description: Filament Change
 gcode:
+  _SAVE_POWER_LOSS_PARAMS
   {% set x = params.X|default(0) %}
   {% set y = params.Y|default(-140) %}
   {% set z = params.Z|default(10)|float %}
@@ -545,6 +527,7 @@ gcode:
   SET_PIN PIN=_motor_cali_a VALUE=0
   SET_PIN PIN=_motor_cali_b VALUE=0
   SET_PIN PIN=_motor_cali_c VALUE=0
+  G4 P1000
 
 [gcode_macro _CALIBRATION_MOTORS_DATA]
 description: Motors Calibration
@@ -1126,14 +1109,7 @@ gcode:
 description: Start G-Codes for Power Loss
 gcode:
   _RELAY_ON
-  {% set sd_filename = printer.virtual_sdcard.file_path|string %}
-  SAVE_VARIABLE VARIABLE=sd_filename VALUE='"{sd_filename}"'
-  SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
-  SAVE_VARIABLE VARIABLE=file_position VALUE=0
-  SAVE_VARIABLE VARIABLE=x_pos VALUE=0.0
-  SAVE_VARIABLE VARIABLE=y_pos VALUE=0.0
-  SAVE_VARIABLE VARIABLE=z_pos VALUE=0.0
-  SAVE_VARIABLE VARIABLE=e_pos VALUE=0.0
+  _CLEAR_POWER_LOSS_PARAMS
   SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
   SET_VELOCITY_LIMIT ACCEL=40000
   SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY=5
@@ -1148,19 +1124,9 @@ gcode:
 [gcode_macro _START_PRINT_RESUME]
 description: Resume G-Codes for Power Loss
 gcode:
-  {% set sd_filename = printer.virtual_sdcard.file_path|string %}
-  SAVE_VARIABLE VARIABLE=sd_filename VALUE='"{sd_filename}"'
-  SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
-  {% set file_position = printer.save_variables.variables.file_position %}
-  SAVE_VARIABLE VARIABLE=file_position VALUE='"{file_position}"'
-  {% set x_pos = printer.save_variables.variables.x_pos %}
-  SAVE_VARIABLE VARIABLE=x_pos VALUE='"{x_pos}"'
-  {% set y_pos = printer.save_variables.variables.y_pos %}
-  SAVE_VARIABLE VARIABLE=y_pos VALUE='"{y_pos}"'
-  {% set z_pos = printer.save_variables.variables.z_pos %}
-  SAVE_VARIABLE VARIABLE=z_pos VALUE='"{z_pos}"'
-  {% set e_pos = printer.save_variables.variables.e_pos %}
-  SAVE_VARIABLE VARIABLE=e_pos VALUE='"{e_pos}"'
+  _RELAY_ON
+  _CLEAR_POWER_LOSS_PARAMS
+  SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
   CLEAR_PAUSE
   _NEOPIXELS_WHITE
   _SCREEN_LED_ON R=0 O=0 W=1
@@ -1169,7 +1135,7 @@ gcode:
 [gcode_macro _END_PRINT]
 description: End G-Codes for Power Loss
 gcode:
-  SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
+  _CLEAR_POWER_LOSS_PARAMS
   SET_STEPPER_ENABLE STEPPER=extruder ENABLE=0
   M106 S128
   UPDATE_DELAYED_GCODE ID=WAIT_COOLING DURATION=60
@@ -1178,34 +1144,104 @@ gcode:
 description: Resume Print from Power Loss
 gcode:
   RESPOND TYPE=command MSG=action:prompt_end
-  {% set file_position = printer.save_variables.variables.file_position %}
-  {% set e_pos = printer.save_variables.variables.e_pos %}
-  {% set x_pos = printer.save_variables.variables.x_pos %}
-  {% set y_pos = printer.save_variables.variables.y_pos %}
-  {% set z_pos = printer.save_variables.variables.z_pos %}
-  {% set last_file = params.GCODE_FILE|default(printer.save_variables.variables.sd_filename)|string %}
-  {% set print_duration = printer.save_variables.variables.print_duration %}
-  {% set fan_speed = printer.save_variables.variables.fan_speed %}
-  {% set nozzle_temp = printer.save_variables.variables.nozzle_temp %}
-  {% set bed_temp = printer.save_variables.variables.bed_temp %}
-  G28
-  SAVE_VARIABLE VARIABLE=plr_flag VALUE=True
-  _SCREEN_LED_ON R=1 O=1 W=0
-  _NEOPIXELS_BED
-  M104 S{nozzle_temp}
-  M140 S{bed_temp}
-  M109 S{nozzle_temp}
-  M190 S{bed_temp}
-  _NEOPIXELS_WHITE
-  _SCREEN_LED_ON R=0 O=0 W=1
-  {% set fan_speed = fan_speed * 255 / 0.90 %}
-  M106 S{fan_speed}
-  G90
-  G92 E{e_pos}
-  M83
-  G1 X{x_pos} Y{y_pos} Z{z_pos}
-  POWER_LOSS_RESTART_PRINT FILENAME='{last_file}' FILEPOSITION={file_position} PRINT_DURATION={print_duration}
+  {% if printer.save_variables.variables.was_interrupted %}
+    {% set file_position = printer.save_variables.variables.file_position %}
+    {% set absolute_extrude = printer.save_variables.variables.absolute_extrude %}
+    {% set e_pos = printer.save_variables.variables.e_pos %}
+    {% set x_pos = printer.save_variables.variables.x_pos %}
+    {% set y_pos = printer.save_variables.variables.y_pos %}
+    {% set z_pos = printer.save_variables.variables.z_pos %}
+    {% set last_file = params.GCODE_FILE|default(printer.save_variables.variables.sd_filename)|string %}
+    {% set print_duration = printer.save_variables.variables.print_duration %}
+    {% set filament_used = printer.save_variables.variables.filament_used %}
+    {% set nozzle_temp = printer.save_variables.variables.nozzle_temp %}
+    {% set bed_temp = printer.save_variables.variables.bed_temp %}
+    {% set bed_temp_out = printer.save_variables.variables.bed_temp_out %}
+    {% set chamber_fan_speed = printer.save_variables.variables.chamber_fan_speed %}  
+    {% set max_velocity = printer.save_variables.variables.max_velocity %}
+    {% set max_accel = printer.save_variables.variables.max_accel %}
+    {% set minimum_cruise_ratio = printer.save_variables.variables.minimum_cruise_ratio %}
+    {% set square_corner_velocity = printer.save_variables.variables.square_corner_velocity %}
+    {% set speed_factor = printer.save_variables.variables.speed_factor %}
+    {% set extrude_factor = printer.save_variables.variables.extrude_factor %}
+    {% set fan_speed = printer.save_variables.variables.fan_speed %}
+    G28
+    _SCREEN_LED_ON R=1 O=1 W=0
+    _NEOPIXELS_BED
+    M104 S{nozzle_temp}
+    M140 S{bed_temp} A1 B0
+    SET_HEATER_TEMPERATURE HEATER=heater_bed_2 TARGET={bed_temp_out} WAIT=0
+    M109 S{nozzle_temp}
+    M190 S{bed_temp} A1 B0
+    SET_HEATER_TEMPERATURE HEATER=heater_bed_2 TARGET={bed_temp_out} WAIT=1
+    _SCREEN_LED_ON R=0 O=1 W=1
+    SET_FAN_SPEED FAN=chamber_fan SPEED={chamber_fan_speed}
+    G90
+    G92 E{e_pos}
+    {% if absolute_extrude %}
+      M82
+    {% else %}
+      M83
+    {% endif%}
+    G1 X{x_pos} Y{y_pos} Z{z_pos} E1 F2000
+    SET_VELOCITY_LIMIT VELOCITY={max_velocity} ACCEL={max_accel} MINIMUM_CRUISE_RATIO={minimum_cruise_ratio} SQUARE_CORNER_VELOCITY={square_corner_velocity}
+    M220 S{speed_factor * 100}
+    M221 S{extrude_factor * 100}
+    {% set fan_speed = fan_speed * 255 / 0.90 %}
+    M106 S{fan_speed}
+    POWER_LOSS_RESTART_PRINT FILENAME='{last_file}' FILEPOSITION={file_position} PRINT_DURATION={print_duration} FILAMENT_USED={filament_used}
+  {% else %}
+    RESPOND MSG="No previous state saved!"
+  {% endif%}
 
+[gcode_macro _SAVE_POWER_LOSS_PARAMS]
+description: Save parameters for Power Loss Recovery
+gcode:
+    SAVE_VARIABLE VARIABLE=sd_filename VALUE='"{printer.virtual_sdcard.file_path|string}"'
+    SAVE_VARIABLE VARIABLE=file_position VALUE={printer.virtual_sdcard.file_position}
+    SAVE_VARIABLE VARIABLE=absolute_extrude VALUE={printer.gcode_move.absolute_extrude}
+    SAVE_VARIABLE VARIABLE=e_pos VALUE={printer.gcode_move.gcode_position.e}
+    SAVE_VARIABLE VARIABLE=x_pos VALUE={printer.gcode_move.gcode_position.x}
+    SAVE_VARIABLE VARIABLE=y_pos VALUE={printer.gcode_move.gcode_position.y}
+    SAVE_VARIABLE VARIABLE=z_pos VALUE={printer.gcode_move.gcode_position.z}
+    SAVE_VARIABLE VARIABLE=speed_factor VALUE={printer.gcode_move.speed_factor}
+    SAVE_VARIABLE VARIABLE=extrude_factor VALUE={printer.gcode_move.extrude_factor}
+    SAVE_VARIABLE VARIABLE=print_duration VALUE={printer.print_stats.print_duration}
+    SAVE_VARIABLE VARIABLE=filament_used VALUE={printer.print_stats.filament_used}
+    SAVE_VARIABLE VARIABLE=fan_speed VALUE={printer.fan.speed|float}
+    SAVE_VARIABLE VARIABLE=nozzle_temp VALUE={printer.extruder.target|float}
+    SAVE_VARIABLE VARIABLE=bed_temp VALUE={printer.heater_bed.target|float}
+    SAVE_VARIABLE VARIABLE=bed_temp_out VALUE={printer["heater_generic heater_bed_2"].target|float}
+    SAVE_VARIABLE VARIABLE=chamber_fan_speed VALUE={printer["fan_generic chamber_fan"].speed|float}
+    SAVE_VARIABLE VARIABLE=max_velocity VALUE={printer.toolhead.max_velocity}
+    SAVE_VARIABLE VARIABLE=max_accel VALUE={printer.toolhead.max_accel}
+    SAVE_VARIABLE VARIABLE=minimum_cruise_ratio VALUE={printer.toolhead.minimum_cruise_ratio}
+    SAVE_VARIABLE VARIABLE=square_corner_velocity VALUE={printer.toolhead.square_corner_velocity}
+    SAVE_VARIABLE VARIABLE=was_interrupted VALUE=True
+
+[gcode_macro _CLEAR_POWER_LOSS_PARAMS]
+description: Clear parameters for Power Loss Recovery
+gcode:
+    SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
+    SAVE_VARIABLE VARIABLE=file_position VALUE=0
+    SAVE_VARIABLE VARIABLE=absolute_extrude VALUE=False
+    SAVE_VARIABLE VARIABLE=e_pos VALUE=0.0
+    SAVE_VARIABLE VARIABLE=x_pos VALUE=0.0
+    SAVE_VARIABLE VARIABLE=y_pos VALUE=0.0
+    SAVE_VARIABLE VARIABLE=z_pos VALUE=0.0
+    SAVE_VARIABLE VARIABLE=speed_factor VALUE=1.0
+    SAVE_VARIABLE VARIABLE=extrude_factor VALUE=1.0
+    SAVE_VARIABLE VARIABLE=print_duration VALUE=0.0
+    SAVE_VARIABLE VARIABLE=filament_used VALUE=0.0
+    SAVE_VARIABLE VARIABLE=fan_speed VALUE=0.0
+    SAVE_VARIABLE VARIABLE=nozzle_temp VALUE=0
+    SAVE_VARIABLE VARIABLE=bed_temp VALUE=0
+    SAVE_VARIABLE VARIABLE=bed_temp_out VALUE=0
+    SAVE_VARIABLE VARIABLE=chamber_fan_speed VALUE=0.0
+    SAVE_VARIABLE VARIABLE=max_velocity VALUE={printer.toolhead.max_velocity}
+    SAVE_VARIABLE VARIABLE=max_accel VALUE={printer.toolhead.max_accel}
+    SAVE_VARIABLE VARIABLE=minimum_cruise_ratio VALUE={printer.toolhead.minimum_cruise_ratio}
+    SAVE_VARIABLE VARIABLE=square_corner_velocity VALUE={printer.toolhead.square_corner_velocity}
 
 ##################################################
 # Gcode Offsets Management
@@ -1432,6 +1468,7 @@ gcode:
     RESPOND MSG="Resonances Calibration done!"
   {% endif %}
   {% if printer.save_variables.variables.was_interrupted %}
+    G4 P5000
     RESPOND TYPE=command MSG="action:prompt_begin Power Loss Recovery"
     RESPOND TYPE=command MSG="action:prompt_text A power loss has occurred!"
     RESPOND TYPE=command MSG="action:prompt_text Do you want to resume current print?"
@@ -1439,13 +1476,12 @@ gcode:
     RESPOND TYPE=command MSG="action:prompt_footer_button RESUME PRINT|RESUME_PRINT_AFTER_PLR|primary"
     RESPOND TYPE=command MSG="action:prompt_show"
   {% endif %}
-  SAVE_VARIABLE VARIABLE=plr_flag VALUE=False
 
 [gcode_macro _CANCEL_PLR]
 description: Cancel Power Loss Recovery
 gcode:
   RESPOND TYPE=command MSG=action:prompt_end
-  SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
+  _CLEAR_POWER_LOSS_PARAMS
 
 [gcode_shell_command Screenshot]
 command: bash /home/pi/flsun-os/macros/screenshot.sh

--- a/config/MMB Cubic (without Silent Kit)/macros.cfg
+++ b/config/MMB Cubic (without Silent Kit)/macros.cfg
@@ -30,7 +30,6 @@ gcode:
     M82
     G28
     M204 S200
-    SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
     {% if X_MIN > 100 or X_MAX > 100 or Y_MIN > 100 or Y_MAX > 100 or X_MIN < -100 or X_MAX < -100 or Y_MIN < -100 or Y_MAX < -100 %}
       M140 S{BED_TEMP} A1 B1
     {% else %}
@@ -64,7 +63,6 @@ gcode:
     M82
     G28
     M204 S200
-    SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
     M140 S{BED_TEMP}
     M190 S{BED_TEMP}
     M104 S140
@@ -90,7 +88,6 @@ gcode:
     M82
     G28
     M204 S200
-    SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
     M140 S{BED_TEMP}
     M190 S{BED_TEMP}
     M104 S140
@@ -113,7 +110,6 @@ gcode:
     G90
     M82
     G28
-    SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
     BED_MESH_PROFILE LOAD=default
     {% if X_MIN > 100 or X_MAX > 100 or Y_MIN > 100 or Y_MAX > 100 or X_MIN < -100 or X_MAX < -100 or Y_MIN < -100 or Y_MAX < -100 %}
       M140 S{BED_TEMP} A1 B1
@@ -1110,10 +1106,11 @@ description: Start G-Codes for Power Loss
 gcode:
   _RELAY_ON
   _CLEAR_POWER_LOSS_PARAMS
-  SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
-  SET_VELOCITY_LIMIT ACCEL=40000
-  SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY=5
-  SET_VELOCITY_LIMIT ACCEL_TO_DECEL=6000
+  SET_TMC_CURRENT STEPPER=extruder CURRENT={printer.configfile.settings['tmc5160 extruder'].run_current}
+  SET_VELOCITY_LIMIT VELOCITY={printer.configfile.settings.printer.max_velocity}
+  SET_VELOCITY_LIMIT ACCEL={printer.configfile.settings.printer.max_accel}
+  SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY={printer.configfile.settings.printer.square_corner_velocity}
+  SET_VELOCITY_LIMIT MINIMUM_CRUISE_RATIO={printer.configfile.settings.printer.minimum_cruise_ratio}
   CLEAR_PAUSE
   _NEOPIXELS_WHITE
   _SCREEN_LED_ON R=0 O=0 W=1
@@ -1126,7 +1123,7 @@ description: Resume G-Codes for Power Loss
 gcode:
   _RELAY_ON
   _CLEAR_POWER_LOSS_PARAMS
-  SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
+  SET_TMC_CURRENT STEPPER=extruder CURRENT={printer.configfile.settings['tmc5160 extruder'].run_current}
   CLEAR_PAUSE
   _NEOPIXELS_WHITE
   _SCREEN_LED_ON R=0 O=0 W=1

--- a/config/MMB Cubic (without Silent Kit)/macros.cfg
+++ b/config/MMB Cubic (without Silent Kit)/macros.cfg
@@ -205,6 +205,7 @@ variable_nozzle_temp: 0
 variable_m600_state: 0
 gcode:
   {% if printer.print_stats.state == "paused" %}
+    M106 S0
     M109 S{nozzle_temp}
     {% if 'VELOCITY' in params|upper %}
       {% set get_params = ('VELOCITY=' + params.VELOCITY) %}

--- a/config/MMB Cubic (without Silent Kit)/macros.cfg
+++ b/config/MMB Cubic (without Silent Kit)/macros.cfg
@@ -706,7 +706,7 @@ gcode:
 [gcode_macro CALIBRATION_PID_HOTEND]
 description: Start Hotend PID Calibration
 gcode:
-  {% set HOTEND_TEMP=params.HOTEND_TEMP|default(350)|float %}
+  {% set HOTEND_TEMP=params.HOTEND_TEMP|default(250)|float %}
   {% if printer.idle_timeout.state == "Printing" %}
     RESPOND TYPE=error MSG="This macro cannot be used while printing!"
   {% else %}

--- a/config/MMB Cubic (without Silent Kit)/macros.cfg
+++ b/config/MMB Cubic (without Silent Kit)/macros.cfg
@@ -1256,26 +1256,36 @@ gcode:
   {% else %}
     {% set offsets = {'x': None,'y': None,'z': None} %}
   {% endif %}
-  {% set ns = namespace(offsets={'x': offsets.x,'y': offsets.y,'z': offsets.z}) %}
-  {%if 'X' in params %}{% set null = ns.offsets.update({'x': params.X}) %}{% endif %}
-  {%if 'Y' in params %}{% set null = ns.offsets.update({'y': params.Y}) %}{% endif %}
-  {%if 'Z' in params %}{% set null = ns.offsets.update({'z': params.Z}) %}{% endif %}
-  {%if 'Z_ADJUST' in params %}
-    {%if ns.offsets.z == None %}
-      {% set null = ns.offsets.update({'z': 0}) %}
+  {%if 'X' in params %}{% set null = offsets.update({'x': params.X}) %}{% endif %}
+  {%if 'Y' in params %}{% set null = offsets.update({'y': params.Y}) %}{% endif %}
+  {%if 'Z' in params %}{% set null = offsets.update({'z': params.Z}) %}{% endif %}
+  {%if 'X_ADJUST' in params %}
+    {%if offsets.x == None %}
+      {% set null = offsets.update({'x': 0}) %}
     {% endif %}
-    {% set null = ns.offsets.update({'z': (ns.offsets.z | float) + (params.Z_ADJUST | float)}) %}
+    {% set null = offsets.update({'x': (offsets.x | float) + (params.X_ADJUST | float)}) %}
+  {% endif %}
+  {%if 'Y_ADJUST' in params %}
+    {%if offsets.y == None %}
+      {% set null = offsets.update({'y': 0}) %}
+    {% endif %}
+    {% set null = offsets.update({'y': (offsets.y | float) + (params.Y_ADJUST | float)}) %}
+  {% endif %}
+  {%if 'Z_ADJUST' in params %}
+    {%if offsets.z == None %}
+      {% set null = offsets.update({'z': 0}) %}
+    {% endif %}
+    {% set null = offsets.update({'z': (offsets.z | float) + (params.Z_ADJUST | float)}) %}
   {% endif %}
   _SET_GCODE_OFFSET {% for p in params %}{'%s=%s '% (p, params[p])}{% endfor %}
-  SAVE_VARIABLE VARIABLE=gcode_offsets VALUE="{ns.offsets}"
+  SAVE_VARIABLE VARIABLE=gcode_offsets VALUE="{offsets}"
 
 [gcode_macro Z_OFFSET_APPLY_ENDSTOP]
 description: Apply Gcode Offsets to Endstops
 rename_existing: _Z_OFFSET_APPLY_ENDSTOP
 gcode:
   _Z_OFFSET_APPLY_ENDSTOP
-  {% set offsets = {'x': None,'y': None,'z': 0} %}
-  SAVE_VARIABLE VARIABLE=gcode_offsets VALUE="{offsets}"
+  SET_GCODE_OFFSET Z=0
 
 
 ##################################################

--- a/config/MMB Cubic (without Silent Kit)/printer.cfg
+++ b/config/MMB Cubic (without Silent Kit)/printer.cfg
@@ -149,7 +149,7 @@ spi_software_sclk_pin: PA6
 spi_software_mosi_pin: PA5
 spi_software_miso_pin: PC4
 sense_resistor: 0.0375
-run_current: 1.2
+run_current: 0.8
 interpolate: True
 stealthchop_threshold: 0
 

--- a/config/MMB Cubic (without Silent Kit)/printer.cfg
+++ b/config/MMB Cubic (without Silent Kit)/printer.cfg
@@ -240,7 +240,7 @@ max_power: 0.90
 [heater_fan heat_sink_fan]
 pin: PA2
 heater_temp: 50.0
-shutdown_speed: 0
+shutdown_speed: 1
 
 [heater_fan motherboard_fan]
 pin: PB5
@@ -257,7 +257,7 @@ pin: PB4
 [heater_fan drying_box_fan]
 pin: PA8
 heater: drying_box
-shutdown_speed: 0
+shutdown_speed: 1
 
 [temperature_sensor _drying_box_temp]
 sensor_type: temperature_host
@@ -430,39 +430,27 @@ switch_pin: PD3
 event_delay: 0.01
 pause_delay: 0.01
 runout_gcode:
-  RESPOND TYPE=error MSG="Power loss detected!"
   _SCREEN_LED_ON R=1 O=0 W=0
   {% if printer.print_stats.state == "printing" %}
-    {% set file_position = printer.virtual_sdcard.file_position %}
-    SAVE_VARIABLE VARIABLE=file_position VALUE={file_position}
-    {% set e_pos = printer.gcode_move.gcode_position.e %}
-    SAVE_VARIABLE VARIABLE=e_pos VALUE={e_pos}
-    {% set x_pos = printer.gcode_move.gcode_position.x %}
-    SAVE_VARIABLE VARIABLE=x_pos VALUE={x_pos}
-    {% set y_pos = printer.gcode_move.gcode_position.y %}
-    SAVE_VARIABLE VARIABLE=y_pos VALUE={y_pos}
-    {% set z_pos = printer.gcode_move.gcode_position.z %}
-    SAVE_VARIABLE VARIABLE=z_pos VALUE={z_pos}
-    {% set print_duration = printer.print_stats.print_duration %}
-    SAVE_VARIABLE VARIABLE=print_duration VALUE={print_duration}
-    {% set fan_speed = printer.fan.speed|float %}
-    SAVE_VARIABLE VARIABLE=fan_speed VALUE={fan_speed}
-    {% set nozzle_temp = printer.extruder.target|float %}
-    SAVE_VARIABLE VARIABLE=nozzle_temp VALUE={nozzle_temp}
-    {% set bed_temp = printer.heater_bed.target|float %}
-    SAVE_VARIABLE VARIABLE=bed_temp VALUE={bed_temp}
-    SAVE_VARIABLE VARIABLE=was_interrupted VALUE=True
+    _SAVE_POWER_LOSS_PARAMS
+    FAN_STOP
+    TURN_OFF_HEATERS
+    SET_FAN_SPEED FAN=chamber_fan SPEED=0
+    _NEOPIXELS_OFF
+    RESPOND TYPE=error MSG="Power loss detected!"
+    M400
+    SET_STEPPER_ENABLE STEPPER=extruder ENABLE=0
     STEPPER_STOP
     _SHUTDOWN
     G4 P5000
   {% endif %}
 insert_gcode:
   {% if printer.print_stats.state != "printing" %}
-    RESPOND TYPE=error MSG="Power loss detected! Shutting down."
     _SCREEN_LED_ON R=1 O=0 W=0
+    RESPOND TYPE=error MSG="Power loss detected! Shutting down."
+    FAN_STOP
     TURN_OFF_HEATERS
     SET_FAN_SPEED FAN=chamber_fan SPEED=0
-    M106.1 S0 
     _SHUTDOWN
     G4 P5000
   {% endif %}

--- a/config/Stock (with Silent Kit)/macros.cfg
+++ b/config/Stock (with Silent Kit)/macros.cfg
@@ -126,7 +126,6 @@ gcode:
       M190 S{BED_TEMP} A1 B0
     {% endif %}
     M104 S{HOTEND_TEMP} T0
-    M107 T0
     G1 Z150 F6000
     G1 X-160 Y0 Z1 F4000
     M109 S{HOTEND_TEMP} T0
@@ -164,25 +163,7 @@ description: Pause Print
 rename_existing: PAUSE_BASE
 gcode:
   {% if printer.print_stats.state == "printing" %}
-    {% set file_position = printer.virtual_sdcard.file_position %}
-    SAVE_VARIABLE VARIABLE=file_position VALUE={file_position}
-    {% set e_pos = printer.gcode_move.gcode_position.e %}
-    SAVE_VARIABLE VARIABLE=e_pos VALUE={e_pos}
-    {% set x_pos = printer.gcode_move.gcode_position.x %}
-    SAVE_VARIABLE VARIABLE=x_pos VALUE={x_pos}
-    {% set y_pos = printer.gcode_move.gcode_position.y %}
-    SAVE_VARIABLE VARIABLE=y_pos VALUE={y_pos}
-    {% set z_pos = printer.gcode_move.gcode_position.z %}
-    SAVE_VARIABLE VARIABLE=z_pos VALUE={z_pos}
-    {% set print_duration = printer.print_stats.print_duration %}
-    SAVE_VARIABLE VARIABLE=print_duration VALUE={print_duration}
-    {% set fan_speed = printer.fan.speed|float %}
-    SAVE_VARIABLE VARIABLE=fan_speed VALUE={fan_speed}
-    {% set nozzle_temp = printer.extruder.target|float %}
-    SAVE_VARIABLE VARIABLE=nozzle_temp VALUE={nozzle_temp}
-    {% set bed_temp = printer.heater_bed.target|float %}
-    SAVE_VARIABLE VARIABLE=bed_temp VALUE={bed_temp}
-    SAVE_VARIABLE VARIABLE=was_interrupted VALUE=True    
+    _SAVE_POWER_LOSS_PARAMS
     {% set x = params.X|default(0) %}
     {% set y = params.Y|default(-140) %}
     {% set z = params.Z|default(10)|float %}
@@ -198,7 +179,7 @@ gcode:
     {% else %}
       {% set z_safe = max_z %}
     {% endif %}
-	{% set fan_speed = printer.fan.speed|float %}
+    {% set fan_speed = printer.fan.speed|float %}
     SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=fan_speed VALUE={fan_speed}
     PAUSE_BASE
     G91
@@ -213,11 +194,11 @@ gcode:
     {% else %}
       RESPOND TYPE=error MSG="Printer not homed!"
     {% endif %}
-	{% set nozzle_temp = printer.extruder.target|float %}
+    {% set nozzle_temp = printer.extruder.target|float %}
     SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=nozzle_temp VALUE={nozzle_temp}
     M104 S90
-	M106 S128
-	M400
+    M106 S128
+    M400
   {% endif %}
 
 [gcode_macro RESUME]
@@ -244,7 +225,7 @@ gcode:
       G90
       M400
     {% endif %}
-    SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
+    _CLEAR_POWER_LOSS_PARAMS
     {% set fan_speed = fan_speed * 255 / 0.5 %}
     M106 S{fan_speed}
     {% if printer['gcode_macro RESUME'].m600_state == 1 %}
@@ -261,7 +242,7 @@ gcode:
 description: Cancel Print
 rename_existing: CANCEL_PRINT_BASE
 gcode:
-  SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
+  _CLEAR_POWER_LOSS_PARAMS
   {% set x = params.X|default(0) %}
   {% set y = params.Y|default(0) %}
   {% set z = params.Z|default(10)|float %}
@@ -306,6 +287,7 @@ gcode:
 [gcode_macro M600]
 description: Filament Change
 gcode:
+  _SAVE_POWER_LOSS_PARAMS
   {% set x = params.X|default(0) %}
   {% set y = params.Y|default(-140) %}
   {% set z = params.Z|default(10)|float %}
@@ -537,6 +519,7 @@ gcode:
   SET_PIN PIN=_motor_cali_a VALUE=0
   SET_PIN PIN=_motor_cali_b VALUE=0
   SET_PIN PIN=_motor_cali_c VALUE=0
+  G4 P1000
 
 [gcode_macro _CALIBRATION_MOTORS_DATA]
 description: Motors Calibration
@@ -1136,14 +1119,7 @@ gcode:
 description: Start G-Codes for Power Loss
 gcode:
   _RELAY_ON
-  {% set sd_filename = printer.virtual_sdcard.file_path|string %}
-  SAVE_VARIABLE VARIABLE=sd_filename VALUE='"{sd_filename}"'
-  SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
-  SAVE_VARIABLE VARIABLE=file_position VALUE=0
-  SAVE_VARIABLE VARIABLE=x_pos VALUE=0.0
-  SAVE_VARIABLE VARIABLE=y_pos VALUE=0.0
-  SAVE_VARIABLE VARIABLE=z_pos VALUE=0.0
-  SAVE_VARIABLE VARIABLE=e_pos VALUE=0.0
+  _CLEAR_POWER_LOSS_PARAMS
   SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
   SET_VELOCITY_LIMIT ACCEL=40000
   SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY=5
@@ -1157,19 +1133,9 @@ gcode:
 [gcode_macro _START_PRINT_RESUME]
 description: Resume G-Codes for Power Loss
 gcode:
-  {% set sd_filename = printer.virtual_sdcard.file_path|string %}
-  SAVE_VARIABLE VARIABLE=sd_filename VALUE='"{sd_filename}"'
-  SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
-  {% set file_position = printer.save_variables.variables.file_position %}
-  SAVE_VARIABLE VARIABLE=file_position VALUE='"{file_position}"'
-  {% set x_pos = printer.save_variables.variables.x_pos %}
-  SAVE_VARIABLE VARIABLE=x_pos VALUE='"{x_pos}"'
-  {% set y_pos = printer.save_variables.variables.y_pos %}
-  SAVE_VARIABLE VARIABLE=y_pos VALUE='"{y_pos}"'
-  {% set z_pos = printer.save_variables.variables.z_pos %}
-  SAVE_VARIABLE VARIABLE=z_pos VALUE='"{z_pos}"'
-  {% set e_pos = printer.save_variables.variables.e_pos %}
-  SAVE_VARIABLE VARIABLE=e_pos VALUE='"{e_pos}"'
+  _RELAY_ON
+  _CLEAR_POWER_LOSS_PARAMS
+  SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
   CLEAR_PAUSE
   _SCREEN_LED_ON R=0 O=0 W=1
   M114 F0
@@ -1177,7 +1143,7 @@ gcode:
 [gcode_macro _END_PRINT]
 description: End G-Codes for Power Loss
 gcode:
-  SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
+  _CLEAR_POWER_LOSS_PARAMS
   SET_STEPPER_ENABLE STEPPER=extruder ENABLE=0
   M106 S128
   UPDATE_DELAYED_GCODE ID=WAIT_COOLING DURATION=60
@@ -1186,32 +1152,103 @@ gcode:
 description: Resume Print from Power Loss
 gcode:
   RESPOND TYPE=command MSG=action:prompt_end
-  {% set file_position = printer.save_variables.variables.file_position %}
-  {% set e_pos = printer.save_variables.variables.e_pos %}
-  {% set x_pos = printer.save_variables.variables.x_pos %}
-  {% set y_pos = printer.save_variables.variables.y_pos %}
-  {% set z_pos = printer.save_variables.variables.z_pos %}
-  {% set last_file = params.GCODE_FILE|default(printer.save_variables.variables.sd_filename)|string %}
-  {% set print_duration = printer.save_variables.variables.print_duration %}
-  {% set fan_speed = printer.save_variables.variables.fan_speed %}
-  {% set nozzle_temp = printer.save_variables.variables.nozzle_temp %}
-  {% set bed_temp = printer.save_variables.variables.bed_temp %}
-  G28
-  SAVE_VARIABLE VARIABLE=plr_flag VALUE=True
-  _SCREEN_LED_ON R=1 O=1 W=0
-  M104 S{nozzle_temp}
-  M140 S{bed_temp}
-  M109 S{nozzle_temp}
-  M190 S{bed_temp}
-  _SCREEN_LED_ON R=0 O=0 W=1
-  {% set fan_speed = fan_speed * 255 / 0.5 %}
-  M106 S{fan_speed}
-  G90
-  G92 E{e_pos}
-  M83
-  G1 X{x_pos} Y{y_pos} Z{z_pos}
-  POWER_LOSS_RESTART_PRINT FILENAME='{last_file}' FILEPOSITION={file_position} PRINT_DURATION={print_duration}
+  {% if printer.save_variables.variables.was_interrupted %}
+    {% set file_position = printer.save_variables.variables.file_position %}
+    {% set absolute_extrude = printer.save_variables.variables.absolute_extrude %}
+    {% set e_pos = printer.save_variables.variables.e_pos %}
+    {% set x_pos = printer.save_variables.variables.x_pos %}
+    {% set y_pos = printer.save_variables.variables.y_pos %}
+    {% set z_pos = printer.save_variables.variables.z_pos %}
+    {% set last_file = params.GCODE_FILE|default(printer.save_variables.variables.sd_filename)|string %}
+    {% set print_duration = printer.save_variables.variables.print_duration %}
+    {% set filament_used = printer.save_variables.variables.filament_used %}
+    {% set nozzle_temp = printer.save_variables.variables.nozzle_temp %}
+    {% set bed_temp = printer.save_variables.variables.bed_temp %}
+    {% set bed_temp_out = printer.save_variables.variables.bed_temp_out %}
+    {% set chamber_fan_speed = printer.save_variables.variables.chamber_fan_speed %}  
+    {% set max_velocity = printer.save_variables.variables.max_velocity %}
+    {% set max_accel = printer.save_variables.variables.max_accel %}
+    {% set minimum_cruise_ratio = printer.save_variables.variables.minimum_cruise_ratio %}
+    {% set square_corner_velocity = printer.save_variables.variables.square_corner_velocity %}
+    {% set speed_factor = printer.save_variables.variables.speed_factor %}
+    {% set extrude_factor = printer.save_variables.variables.extrude_factor %}
+    {% set fan_speed = printer.save_variables.variables.fan_speed %}
+    G28
+    _SCREEN_LED_ON R=1 O=1 W=0
+    M104 S{nozzle_temp}
+    M140 S{bed_temp} A1 B0
+    SET_HEATER_TEMPERATURE HEATER=heater_bed_2 TARGET={bed_temp_out} WAIT=0
+    M109 S{nozzle_temp}
+    M190 S{bed_temp} A1 B0
+    SET_HEATER_TEMPERATURE HEATER=heater_bed_2 TARGET={bed_temp_out} WAIT=1
+    _SCREEN_LED_ON R=0 O=1 W=1
+    SET_FAN_SPEED FAN=chamber_fan SPEED={chamber_fan_speed}
+    G90
+    G92 E{e_pos}
+    {% if absolute_extrude %}
+      M82
+    {% else %}
+      M83
+    {% endif%}
+    G1 X{x_pos} Y{y_pos} Z{z_pos} E1 F2000
+    SET_VELOCITY_LIMIT VELOCITY={max_velocity} ACCEL={max_accel} MINIMUM_CRUISE_RATIO={minimum_cruise_ratio} SQUARE_CORNER_VELOCITY={square_corner_velocity}
+    M220 S{speed_factor * 100}
+    M221 S{extrude_factor * 100}
+    {% set fan_speed = fan_speed * 255 / 0.90 %}
+    M106 S{fan_speed}
+    POWER_LOSS_RESTART_PRINT FILENAME='{last_file}' FILEPOSITION={file_position} PRINT_DURATION={print_duration} FILAMENT_USED={filament_used}
+  {% else %}
+    RESPOND MSG="No previous state saved!"
+  {% endif%}
 
+[gcode_macro _SAVE_POWER_LOSS_PARAMS]
+description: Save parameters for Power Loss Recovery
+gcode:
+    SAVE_VARIABLE VARIABLE=sd_filename VALUE='"{printer.virtual_sdcard.file_path|string}"'
+    SAVE_VARIABLE VARIABLE=file_position VALUE={printer.virtual_sdcard.file_position}
+    SAVE_VARIABLE VARIABLE=absolute_extrude VALUE={printer.gcode_move.absolute_extrude}
+    SAVE_VARIABLE VARIABLE=e_pos VALUE={printer.gcode_move.gcode_position.e}
+    SAVE_VARIABLE VARIABLE=x_pos VALUE={printer.gcode_move.gcode_position.x}
+    SAVE_VARIABLE VARIABLE=y_pos VALUE={printer.gcode_move.gcode_position.y}
+    SAVE_VARIABLE VARIABLE=z_pos VALUE={printer.gcode_move.gcode_position.z}
+    SAVE_VARIABLE VARIABLE=speed_factor VALUE={printer.gcode_move.speed_factor}
+    SAVE_VARIABLE VARIABLE=extrude_factor VALUE={printer.gcode_move.extrude_factor}
+    SAVE_VARIABLE VARIABLE=print_duration VALUE={printer.print_stats.print_duration}
+    SAVE_VARIABLE VARIABLE=filament_used VALUE={printer.print_stats.filament_used}
+    SAVE_VARIABLE VARIABLE=fan_speed VALUE={printer.fan.speed|float}
+    SAVE_VARIABLE VARIABLE=nozzle_temp VALUE={printer.extruder.target|float}
+    SAVE_VARIABLE VARIABLE=bed_temp VALUE={printer.heater_bed.target|float}
+    SAVE_VARIABLE VARIABLE=bed_temp_out VALUE={printer["heater_generic heater_bed_2"].target|float}
+    SAVE_VARIABLE VARIABLE=chamber_fan_speed VALUE={printer["fan_generic chamber_fan"].speed|float}
+    SAVE_VARIABLE VARIABLE=max_velocity VALUE={printer.toolhead.max_velocity}
+    SAVE_VARIABLE VARIABLE=max_accel VALUE={printer.toolhead.max_accel}
+    SAVE_VARIABLE VARIABLE=minimum_cruise_ratio VALUE={printer.toolhead.minimum_cruise_ratio}
+    SAVE_VARIABLE VARIABLE=square_corner_velocity VALUE={printer.toolhead.square_corner_velocity}
+    SAVE_VARIABLE VARIABLE=was_interrupted VALUE=True
+
+[gcode_macro _CLEAR_POWER_LOSS_PARAMS]
+description: Clear parameters for Power Loss Recovery
+gcode:
+    SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
+    SAVE_VARIABLE VARIABLE=file_position VALUE=0
+    SAVE_VARIABLE VARIABLE=absolute_extrude VALUE=False
+    SAVE_VARIABLE VARIABLE=e_pos VALUE=0.0
+    SAVE_VARIABLE VARIABLE=x_pos VALUE=0.0
+    SAVE_VARIABLE VARIABLE=y_pos VALUE=0.0
+    SAVE_VARIABLE VARIABLE=z_pos VALUE=0.0
+    SAVE_VARIABLE VARIABLE=speed_factor VALUE=1.0
+    SAVE_VARIABLE VARIABLE=extrude_factor VALUE=1.0
+    SAVE_VARIABLE VARIABLE=print_duration VALUE=0.0
+    SAVE_VARIABLE VARIABLE=filament_used VALUE=0.0
+    SAVE_VARIABLE VARIABLE=fan_speed VALUE=0.0
+    SAVE_VARIABLE VARIABLE=nozzle_temp VALUE=0
+    SAVE_VARIABLE VARIABLE=bed_temp VALUE=0
+    SAVE_VARIABLE VARIABLE=bed_temp_out VALUE=0
+    SAVE_VARIABLE VARIABLE=chamber_fan_speed VALUE=0.0
+    SAVE_VARIABLE VARIABLE=max_velocity VALUE={printer.toolhead.max_velocity}
+    SAVE_VARIABLE VARIABLE=max_accel VALUE={printer.toolhead.max_accel}
+    SAVE_VARIABLE VARIABLE=minimum_cruise_ratio VALUE={printer.toolhead.minimum_cruise_ratio}
+    SAVE_VARIABLE VARIABLE=square_corner_velocity VALUE={printer.toolhead.square_corner_velocity}
 
 ##################################################
 # Gcode Offsets Management
@@ -1438,6 +1475,7 @@ gcode:
     RESPOND MSG="Resonances Calibration done!"
   {% endif %}
   {% if printer.save_variables.variables.was_interrupted %}
+    G4 P5000
     RESPOND TYPE=command MSG="action:prompt_begin Power Loss Recovery"
     RESPOND TYPE=command MSG="action:prompt_text A power loss has occurred!"
     RESPOND TYPE=command MSG="action:prompt_text Do you want to resume current print?"
@@ -1445,13 +1483,12 @@ gcode:
     RESPOND TYPE=command MSG="action:prompt_footer_button RESUME PRINT|RESUME_PRINT_AFTER_PLR|primary"
     RESPOND TYPE=command MSG="action:prompt_show"
   {% endif %}
-  SAVE_VARIABLE VARIABLE=plr_flag VALUE=False
 
 [gcode_macro _CANCEL_PLR]
 description: Cancel Power Loss Recovery
 gcode:
   RESPOND TYPE=command MSG=action:prompt_end
-  SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
+  _CLEAR_POWER_LOSS_PARAMS
 
 [gcode_shell_command Screenshot]
 command: bash /home/pi/flsun-os/macros/screenshot.sh

--- a/config/Stock (with Silent Kit)/macros.cfg
+++ b/config/Stock (with Silent Kit)/macros.cfg
@@ -1194,7 +1194,7 @@ gcode:
     SET_VELOCITY_LIMIT VELOCITY={max_velocity} ACCEL={max_accel} MINIMUM_CRUISE_RATIO={minimum_cruise_ratio} SQUARE_CORNER_VELOCITY={square_corner_velocity}
     M220 S{speed_factor * 100}
     M221 S{extrude_factor * 100}
-    {% set fan_speed = fan_speed * 255 / 0.90 %}
+    {% set fan_speed = fan_speed * 255 / 0.5 %}
     M106 S{fan_speed}
     POWER_LOSS_RESTART_PRINT FILENAME='{last_file}' FILEPOSITION={file_position} PRINT_DURATION={print_duration} FILAMENT_USED={filament_used}
   {% else %}

--- a/config/Stock (with Silent Kit)/macros.cfg
+++ b/config/Stock (with Silent Kit)/macros.cfg
@@ -205,6 +205,7 @@ variable_nozzle_temp: 0
 variable_m600_state: 0
 gcode:
   {% if printer.print_stats.state == "paused" %}
+    M106 S0
     M109 S{nozzle_temp}
     {% if 'VELOCITY' in params|upper %}
       {% set get_params = ('VELOCITY=' + params.VELOCITY) %}

--- a/config/Stock (with Silent Kit)/macros.cfg
+++ b/config/Stock (with Silent Kit)/macros.cfg
@@ -1263,26 +1263,36 @@ gcode:
   {% else %}
     {% set offsets = {'x': None,'y': None,'z': None} %}
   {% endif %}
-  {% set ns = namespace(offsets={'x': offsets.x,'y': offsets.y,'z': offsets.z}) %}
-  {%if 'X' in params %}{% set null = ns.offsets.update({'x': params.X}) %}{% endif %}
-  {%if 'Y' in params %}{% set null = ns.offsets.update({'y': params.Y}) %}{% endif %}
-  {%if 'Z' in params %}{% set null = ns.offsets.update({'z': params.Z}) %}{% endif %}
-  {%if 'Z_ADJUST' in params %}
-    {%if ns.offsets.z == None %}
-      {% set null = ns.offsets.update({'z': 0}) %}
+  {%if 'X' in params %}{% set null = offsets.update({'x': params.X}) %}{% endif %}
+  {%if 'Y' in params %}{% set null = offsets.update({'y': params.Y}) %}{% endif %}
+  {%if 'Z' in params %}{% set null = offsets.update({'z': params.Z}) %}{% endif %}
+  {%if 'X_ADJUST' in params %}
+    {%if offsets.x == None %}
+      {% set null = offsets.update({'x': 0}) %}
     {% endif %}
-    {% set null = ns.offsets.update({'z': (ns.offsets.z | float) + (params.Z_ADJUST | float)}) %}
+    {% set null = offsets.update({'x': (offsets.x | float) + (params.X_ADJUST | float)}) %}
+  {% endif %}
+  {%if 'Y_ADJUST' in params %}
+    {%if offsets.y == None %}
+      {% set null = offsets.update({'y': 0}) %}
+    {% endif %}
+    {% set null = offsets.update({'y': (offsets.y | float) + (params.Y_ADJUST | float)}) %}
+  {% endif %}
+  {%if 'Z_ADJUST' in params %}
+    {%if offsets.z == None %}
+      {% set null = offsets.update({'z': 0}) %}
+    {% endif %}
+    {% set null = offsets.update({'z': (offsets.z | float) + (params.Z_ADJUST | float)}) %}
   {% endif %}
   _SET_GCODE_OFFSET {% for p in params %}{'%s=%s '% (p, params[p])}{% endfor %}
-  SAVE_VARIABLE VARIABLE=gcode_offsets VALUE="{ns.offsets}"
+  SAVE_VARIABLE VARIABLE=gcode_offsets VALUE="{offsets}"
 
 [gcode_macro Z_OFFSET_APPLY_ENDSTOP]
 description: Apply Gcode Offsets to Endstops
 rename_existing: _Z_OFFSET_APPLY_ENDSTOP
 gcode:
   _Z_OFFSET_APPLY_ENDSTOP
-  {% set offsets = {'x': None,'y': None,'z': 0} %}
-  SAVE_VARIABLE VARIABLE=gcode_offsets VALUE="{offsets}"
+  SET_GCODE_OFFSET Z=0
 
 
 ##################################################

--- a/config/Stock (with Silent Kit)/macros.cfg
+++ b/config/Stock (with Silent Kit)/macros.cfg
@@ -30,7 +30,6 @@ gcode:
     M82
     G28
     M204 S200
-    SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
     {% if X_MIN > 100 or X_MAX > 100 or Y_MIN > 100 or Y_MAX > 100 or X_MIN < -100 or X_MAX < -100 or Y_MIN < -100 or Y_MAX < -100 %}
       M140 S{BED_TEMP} A1 B1
     {% else %}
@@ -64,7 +63,6 @@ gcode:
     M82
     G28
     M204 S200
-    SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
     M140 S{BED_TEMP}
     M190 S{BED_TEMP}
     M104 S140
@@ -90,7 +88,6 @@ gcode:
     M82
     G28
     M204 S200
-    SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
     M140 S{BED_TEMP}
     M190 S{BED_TEMP}
     M104 S140
@@ -113,7 +110,6 @@ gcode:
     G90
     M82
     G28
-    SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
     BED_MESH_PROFILE LOAD=default
     {% if X_MIN > 100 or X_MAX > 100 or Y_MIN > 100 or Y_MAX > 100 or X_MIN < -100 or X_MAX < -100 or Y_MIN < -100 or Y_MAX < -100 %}
       M140 S{BED_TEMP} A1 B1
@@ -1120,10 +1116,11 @@ description: Start G-Codes for Power Loss
 gcode:
   _RELAY_ON
   _CLEAR_POWER_LOSS_PARAMS
-  SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
-  SET_VELOCITY_LIMIT ACCEL=40000
-  SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY=5
-  SET_VELOCITY_LIMIT ACCEL_TO_DECEL=6000
+  SET_TMC_CURRENT STEPPER=extruder CURRENT={printer.configfile.settings['tmc5160 extruder'].run_current}
+  SET_VELOCITY_LIMIT VELOCITY={printer.configfile.settings.printer.max_velocity}
+  SET_VELOCITY_LIMIT ACCEL={printer.configfile.settings.printer.max_accel}
+  SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY={printer.configfile.settings.printer.square_corner_velocity}
+  SET_VELOCITY_LIMIT MINIMUM_CRUISE_RATIO={printer.configfile.settings.printer.minimum_cruise_ratio}
   CLEAR_PAUSE
   _SCREEN_LED_ON R=0 O=0 W=1
   M106 S255
@@ -1135,7 +1132,7 @@ description: Resume G-Codes for Power Loss
 gcode:
   _RELAY_ON
   _CLEAR_POWER_LOSS_PARAMS
-  SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
+  SET_TMC_CURRENT STEPPER=extruder CURRENT={printer.configfile.settings['tmc5160 extruder'].run_current}
   CLEAR_PAUSE
   _SCREEN_LED_ON R=0 O=0 W=1
   M114 F0

--- a/config/Stock (with Silent Kit)/macros.cfg
+++ b/config/Stock (with Silent Kit)/macros.cfg
@@ -695,7 +695,7 @@ gcode:
 [gcode_macro CALIBRATION_PID_HOTEND]
 description: Start Hotend PID Calibration
 gcode:
-  {% set HOTEND_TEMP=params.HOTEND_TEMP|default(350)|float %}
+  {% set HOTEND_TEMP=params.HOTEND_TEMP|default(250)|float %}
   {% if printer.idle_timeout.state == "Printing" %}
     RESPOND TYPE=error MSG="This macro cannot be used while printing!"
   {% else %}

--- a/config/Stock (with Silent Kit)/printer.cfg
+++ b/config/Stock (with Silent Kit)/printer.cfg
@@ -239,7 +239,7 @@ max_power: 0.5
 [heater_fan heat_sink_fan]
 pin: PA2
 heater_temp: 50.0
-shutdown_speed: 0
+shutdown_speed: 1
 
 [heater_fan motherboard_fan]
 pin: PB5
@@ -256,7 +256,7 @@ pin: PB4
 [heater_fan drying_box_fan]
 pin: PA8
 heater: drying_box
-shutdown_speed: 0
+shutdown_speed: 1
 
 [temperature_sensor _drying_box_temp]
 sensor_type: temperature_host
@@ -429,39 +429,27 @@ switch_pin: PD3
 event_delay: 0.01
 pause_delay: 0.01
 runout_gcode:
-  RESPOND TYPE=error MSG="Power loss detected!"
   _SCREEN_LED_ON R=1 O=0 W=0
   {% if printer.print_stats.state == "printing" %}
-    {% set file_position = printer.virtual_sdcard.file_position %}
-    SAVE_VARIABLE VARIABLE=file_position VALUE={file_position}
-    {% set e_pos = printer.gcode_move.gcode_position.e %}
-    SAVE_VARIABLE VARIABLE=e_pos VALUE={e_pos}
-    {% set x_pos = printer.gcode_move.gcode_position.x %}
-    SAVE_VARIABLE VARIABLE=x_pos VALUE={x_pos}
-    {% set y_pos = printer.gcode_move.gcode_position.y %}
-    SAVE_VARIABLE VARIABLE=y_pos VALUE={y_pos}
-    {% set z_pos = printer.gcode_move.gcode_position.z %}
-    SAVE_VARIABLE VARIABLE=z_pos VALUE={z_pos}
-    {% set print_duration = printer.print_stats.print_duration %}
-    SAVE_VARIABLE VARIABLE=print_duration VALUE={print_duration}
-    {% set fan_speed = printer.fan.speed|float %}
-    SAVE_VARIABLE VARIABLE=fan_speed VALUE={fan_speed}
-    {% set nozzle_temp = printer.extruder.target|float %}
-    SAVE_VARIABLE VARIABLE=nozzle_temp VALUE={nozzle_temp}
-    {% set bed_temp = printer.heater_bed.target|float %}
-    SAVE_VARIABLE VARIABLE=bed_temp VALUE={bed_temp}
-    SAVE_VARIABLE VARIABLE=was_interrupted VALUE=True
+    _SAVE_POWER_LOSS_PARAMS
+    FAN_STOP
+    TURN_OFF_HEATERS
+    SET_FAN_SPEED FAN=chamber_fan SPEED=0
+    _CHAMBER_LED_OFF
+    RESPOND TYPE=error MSG="Power loss detected!"
+    M400
+    SET_STEPPER_ENABLE STEPPER=extruder ENABLE=0
     STEPPER_STOP
     _SHUTDOWN
     G4 P5000
   {% endif %}
 insert_gcode:
   {% if printer.print_stats.state != "printing" %}
-    RESPOND TYPE=error MSG="Power loss detected! Shutting down."
     _SCREEN_LED_ON R=1 O=0 W=0
+    RESPOND TYPE=error MSG="Power loss detected! Shutting down."
+    FAN_STOP
     TURN_OFF_HEATERS
     SET_FAN_SPEED FAN=chamber_fan SPEED=0
-    M106.1 S0 
     _SHUTDOWN
     G4 P5000
   {% endif %}

--- a/config/Stock (with Silent Kit)/printer.cfg
+++ b/config/Stock (with Silent Kit)/printer.cfg
@@ -148,7 +148,7 @@ spi_software_sclk_pin: PA6
 spi_software_mosi_pin: PA5
 spi_software_miso_pin: PC4
 sense_resistor: 0.0375
-run_current: 1.2
+run_current: 0.8
 interpolate: True
 stealthchop_threshold: 0
 

--- a/config/Stock (without Silent Kit)/macros.cfg
+++ b/config/Stock (without Silent Kit)/macros.cfg
@@ -205,6 +205,7 @@ variable_nozzle_temp: 0
 variable_m600_state: 0
 gcode:
   {% if printer.print_stats.state == "paused" %}
+    M106 S0
     M109 S{nozzle_temp}
     {% if 'VELOCITY' in params|upper %}
       {% set get_params = ('VELOCITY=' + params.VELOCITY) %}

--- a/config/Stock (without Silent Kit)/macros.cfg
+++ b/config/Stock (without Silent Kit)/macros.cfg
@@ -1263,26 +1263,36 @@ gcode:
   {% else %}
     {% set offsets = {'x': None,'y': None,'z': None} %}
   {% endif %}
-  {% set ns = namespace(offsets={'x': offsets.x,'y': offsets.y,'z': offsets.z}) %}
-  {%if 'X' in params %}{% set null = ns.offsets.update({'x': params.X}) %}{% endif %}
-  {%if 'Y' in params %}{% set null = ns.offsets.update({'y': params.Y}) %}{% endif %}
-  {%if 'Z' in params %}{% set null = ns.offsets.update({'z': params.Z}) %}{% endif %}
-  {%if 'Z_ADJUST' in params %}
-    {%if ns.offsets.z == None %}
-      {% set null = ns.offsets.update({'z': 0}) %}
+  {%if 'X' in params %}{% set null = offsets.update({'x': params.X}) %}{% endif %}
+  {%if 'Y' in params %}{% set null = offsets.update({'y': params.Y}) %}{% endif %}
+  {%if 'Z' in params %}{% set null = offsets.update({'z': params.Z}) %}{% endif %}
+  {%if 'X_ADJUST' in params %}
+    {%if offsets.x == None %}
+      {% set null = offsets.update({'x': 0}) %}
     {% endif %}
-    {% set null = ns.offsets.update({'z': (ns.offsets.z | float) + (params.Z_ADJUST | float)}) %}
+    {% set null = offsets.update({'x': (offsets.x | float) + (params.X_ADJUST | float)}) %}
+  {% endif %}
+  {%if 'Y_ADJUST' in params %}
+    {%if offsets.y == None %}
+      {% set null = offsets.update({'y': 0}) %}
+    {% endif %}
+    {% set null = offsets.update({'y': (offsets.y | float) + (params.Y_ADJUST | float)}) %}
+  {% endif %}
+  {%if 'Z_ADJUST' in params %}
+    {%if offsets.z == None %}
+      {% set null = offsets.update({'z': 0}) %}
+    {% endif %}
+    {% set null = offsets.update({'z': (offsets.z | float) + (params.Z_ADJUST | float)}) %}
   {% endif %}
   _SET_GCODE_OFFSET {% for p in params %}{'%s=%s '% (p, params[p])}{% endfor %}
-  SAVE_VARIABLE VARIABLE=gcode_offsets VALUE="{ns.offsets}"
+  SAVE_VARIABLE VARIABLE=gcode_offsets VALUE="{offsets}"
 
 [gcode_macro Z_OFFSET_APPLY_ENDSTOP]
 description: Apply Gcode Offsets to Endstops
 rename_existing: _Z_OFFSET_APPLY_ENDSTOP
 gcode:
   _Z_OFFSET_APPLY_ENDSTOP
-  {% set offsets = {'x': None,'y': None,'z': 0} %}
-  SAVE_VARIABLE VARIABLE=gcode_offsets VALUE="{offsets}"
+  SET_GCODE_OFFSET Z=0
 
 
 ##################################################

--- a/config/Stock (without Silent Kit)/macros.cfg
+++ b/config/Stock (without Silent Kit)/macros.cfg
@@ -30,7 +30,6 @@ gcode:
     M82
     G28
     M204 S200
-    SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
     {% if X_MIN > 100 or X_MAX > 100 or Y_MIN > 100 or Y_MAX > 100 or X_MIN < -100 or X_MAX < -100 or Y_MIN < -100 or Y_MAX < -100 %}
       M140 S{BED_TEMP} A1 B1
     {% else %}
@@ -64,7 +63,6 @@ gcode:
     M82
     G28
     M204 S200
-    SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
     M140 S{BED_TEMP}
     M190 S{BED_TEMP}
     M104 S140
@@ -90,7 +88,6 @@ gcode:
     M82
     G28
     M204 S200
-    SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
     M140 S{BED_TEMP}
     M190 S{BED_TEMP}
     M104 S140
@@ -113,7 +110,6 @@ gcode:
     G90
     M82
     G28
-    SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
     BED_MESH_PROFILE LOAD=default
     {% if X_MIN > 100 or X_MAX > 100 or Y_MIN > 100 or Y_MAX > 100 or X_MIN < -100 or X_MAX < -100 or Y_MIN < -100 or Y_MAX < -100 %}
       M140 S{BED_TEMP} A1 B1
@@ -1120,10 +1116,11 @@ description: Start G-Codes for Power Loss
 gcode:
   _RELAY_ON
   _CLEAR_POWER_LOSS_PARAMS
-  SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
-  SET_VELOCITY_LIMIT ACCEL=40000
-  SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY=5
-  SET_VELOCITY_LIMIT ACCEL_TO_DECEL=6000
+  SET_TMC_CURRENT STEPPER=extruder CURRENT={printer.configfile.settings['tmc5160 extruder'].run_current}
+  SET_VELOCITY_LIMIT VELOCITY={printer.configfile.settings.printer.max_velocity}
+  SET_VELOCITY_LIMIT ACCEL={printer.configfile.settings.printer.max_accel}
+  SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY={printer.configfile.settings.printer.square_corner_velocity}
+  SET_VELOCITY_LIMIT MINIMUM_CRUISE_RATIO={printer.configfile.settings.printer.minimum_cruise_ratio}
   CLEAR_PAUSE
   _SCREEN_LED_ON R=0 O=0 W=1
   M106 S255
@@ -1135,7 +1132,7 @@ description: Resume G-Codes for Power Loss
 gcode:
   _RELAY_ON
   _CLEAR_POWER_LOSS_PARAMS
-  SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
+  SET_TMC_CURRENT STEPPER=extruder CURRENT={printer.configfile.settings['tmc5160 extruder'].run_current}
   CLEAR_PAUSE
   _SCREEN_LED_ON R=0 O=0 W=1
   M114 F0

--- a/config/Stock (without Silent Kit)/macros.cfg
+++ b/config/Stock (without Silent Kit)/macros.cfg
@@ -126,7 +126,6 @@ gcode:
       M190 S{BED_TEMP} A1 B0
     {% endif %}
     M104 S{HOTEND_TEMP} T0
-    M107 T0
     G1 Z150 F6000
     G1 X-160 Y0 Z1 F4000
     M109 S{HOTEND_TEMP} T0
@@ -164,25 +163,7 @@ description: Pause Print
 rename_existing: PAUSE_BASE
 gcode:
   {% if printer.print_stats.state == "printing" %}
-    {% set file_position = printer.virtual_sdcard.file_position %}
-    SAVE_VARIABLE VARIABLE=file_position VALUE={file_position}
-    {% set e_pos = printer.gcode_move.gcode_position.e %}
-    SAVE_VARIABLE VARIABLE=e_pos VALUE={e_pos}
-    {% set x_pos = printer.gcode_move.gcode_position.x %}
-    SAVE_VARIABLE VARIABLE=x_pos VALUE={x_pos}
-    {% set y_pos = printer.gcode_move.gcode_position.y %}
-    SAVE_VARIABLE VARIABLE=y_pos VALUE={y_pos}
-    {% set z_pos = printer.gcode_move.gcode_position.z %}
-    SAVE_VARIABLE VARIABLE=z_pos VALUE={z_pos}
-    {% set print_duration = printer.print_stats.print_duration %}
-    SAVE_VARIABLE VARIABLE=print_duration VALUE={print_duration}
-    {% set fan_speed = printer.fan.speed|float %}
-    SAVE_VARIABLE VARIABLE=fan_speed VALUE={fan_speed}
-    {% set nozzle_temp = printer.extruder.target|float %}
-    SAVE_VARIABLE VARIABLE=nozzle_temp VALUE={nozzle_temp}
-    {% set bed_temp = printer.heater_bed.target|float %}
-    SAVE_VARIABLE VARIABLE=bed_temp VALUE={bed_temp}
-    SAVE_VARIABLE VARIABLE=was_interrupted VALUE=True    
+    _SAVE_POWER_LOSS_PARAMS
     {% set x = params.X|default(0) %}
     {% set y = params.Y|default(-140) %}
     {% set z = params.Z|default(10)|float %}
@@ -198,7 +179,7 @@ gcode:
     {% else %}
       {% set z_safe = max_z %}
     {% endif %}
-	{% set fan_speed = printer.fan.speed|float %}
+    {% set fan_speed = printer.fan.speed|float %}
     SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=fan_speed VALUE={fan_speed}
     PAUSE_BASE
     G91
@@ -213,11 +194,11 @@ gcode:
     {% else %}
       RESPOND TYPE=error MSG="Printer not homed!"
     {% endif %}
-	{% set nozzle_temp = printer.extruder.target|float %}
+    {% set nozzle_temp = printer.extruder.target|float %}
     SET_GCODE_VARIABLE MACRO=RESUME VARIABLE=nozzle_temp VALUE={nozzle_temp}
     M104 S90
-	M106 S128
-	M400
+    M106 S128
+    M400
   {% endif %}
 
 [gcode_macro RESUME]
@@ -244,7 +225,7 @@ gcode:
       G90
       M400
     {% endif %}
-    SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
+    _CLEAR_POWER_LOSS_PARAMS
     {% set fan_speed = fan_speed * 255 / 0.90 %}
     M106 S{fan_speed}
     {% if printer['gcode_macro RESUME'].m600_state == 1 %}
@@ -261,7 +242,7 @@ gcode:
 description: Cancel Print
 rename_existing: CANCEL_PRINT_BASE
 gcode:
-  SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
+  _CLEAR_POWER_LOSS_PARAMS
   {% set x = params.X|default(0) %}
   {% set y = params.Y|default(0) %}
   {% set z = params.Z|default(10)|float %}
@@ -306,6 +287,7 @@ gcode:
 [gcode_macro M600]
 description: Filament Change
 gcode:
+  _SAVE_POWER_LOSS_PARAMS
   {% set x = params.X|default(0) %}
   {% set y = params.Y|default(-140) %}
   {% set z = params.Z|default(10)|float %}
@@ -537,6 +519,7 @@ gcode:
   SET_PIN PIN=_motor_cali_a VALUE=0
   SET_PIN PIN=_motor_cali_b VALUE=0
   SET_PIN PIN=_motor_cali_c VALUE=0
+  G4 P1000
 
 [gcode_macro _CALIBRATION_MOTORS_DATA]
 description: Motors Calibration
@@ -1136,14 +1119,7 @@ gcode:
 description: Start G-Codes for Power Loss
 gcode:
   _RELAY_ON
-  {% set sd_filename = printer.virtual_sdcard.file_path|string %}
-  SAVE_VARIABLE VARIABLE=sd_filename VALUE='"{sd_filename}"'
-  SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
-  SAVE_VARIABLE VARIABLE=file_position VALUE=0
-  SAVE_VARIABLE VARIABLE=x_pos VALUE=0.0
-  SAVE_VARIABLE VARIABLE=y_pos VALUE=0.0
-  SAVE_VARIABLE VARIABLE=z_pos VALUE=0.0
-  SAVE_VARIABLE VARIABLE=e_pos VALUE=0.0
+  _CLEAR_POWER_LOSS_PARAMS
   SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
   SET_VELOCITY_LIMIT ACCEL=40000
   SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY=5
@@ -1157,19 +1133,9 @@ gcode:
 [gcode_macro _START_PRINT_RESUME]
 description: Resume G-Codes for Power Loss
 gcode:
-  {% set sd_filename = printer.virtual_sdcard.file_path|string %}
-  SAVE_VARIABLE VARIABLE=sd_filename VALUE='"{sd_filename}"'
-  SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
-  {% set file_position = printer.save_variables.variables.file_position %}
-  SAVE_VARIABLE VARIABLE=file_position VALUE='"{file_position}"'
-  {% set x_pos = printer.save_variables.variables.x_pos %}
-  SAVE_VARIABLE VARIABLE=x_pos VALUE='"{x_pos}"'
-  {% set y_pos = printer.save_variables.variables.y_pos %}
-  SAVE_VARIABLE VARIABLE=y_pos VALUE='"{y_pos}"'
-  {% set z_pos = printer.save_variables.variables.z_pos %}
-  SAVE_VARIABLE VARIABLE=z_pos VALUE='"{z_pos}"'
-  {% set e_pos = printer.save_variables.variables.e_pos %}
-  SAVE_VARIABLE VARIABLE=e_pos VALUE='"{e_pos}"'
+  _RELAY_ON
+  _CLEAR_POWER_LOSS_PARAMS
+  SET_TMC_CURRENT STEPPER=extruder CURRENT=0.8
   CLEAR_PAUSE
   _SCREEN_LED_ON R=0 O=0 W=1
   M114 F0
@@ -1177,7 +1143,7 @@ gcode:
 [gcode_macro _END_PRINT]
 description: End G-Codes for Power Loss
 gcode:
-  SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
+  _CLEAR_POWER_LOSS_PARAMS
   SET_STEPPER_ENABLE STEPPER=extruder ENABLE=0
   M106 S128
   UPDATE_DELAYED_GCODE ID=WAIT_COOLING DURATION=60
@@ -1186,32 +1152,103 @@ gcode:
 description: Resume Print from Power Loss
 gcode:
   RESPOND TYPE=command MSG=action:prompt_end
-  {% set file_position = printer.save_variables.variables.file_position %}
-  {% set e_pos = printer.save_variables.variables.e_pos %}
-  {% set x_pos = printer.save_variables.variables.x_pos %}
-  {% set y_pos = printer.save_variables.variables.y_pos %}
-  {% set z_pos = printer.save_variables.variables.z_pos %}
-  {% set last_file = params.GCODE_FILE|default(printer.save_variables.variables.sd_filename)|string %}
-  {% set print_duration = printer.save_variables.variables.print_duration %}
-  {% set fan_speed = printer.save_variables.variables.fan_speed %}
-  {% set nozzle_temp = printer.save_variables.variables.nozzle_temp %}
-  {% set bed_temp = printer.save_variables.variables.bed_temp %}
-  G28
-  SAVE_VARIABLE VARIABLE=plr_flag VALUE=True
-  _SCREEN_LED_ON R=1 O=1 W=0
-  M104 S{nozzle_temp}
-  M140 S{bed_temp}
-  M109 S{nozzle_temp}
-  M190 S{bed_temp}
-  _SCREEN_LED_ON R=0 O=0 W=1
-  {% set fan_speed = fan_speed * 255 / 0.90 %}
-  M106 S{fan_speed}
-  G90
-  G92 E{e_pos}
-  M83
-  G1 X{x_pos} Y{y_pos} Z{z_pos}
-  POWER_LOSS_RESTART_PRINT FILENAME='{last_file}' FILEPOSITION={file_position} PRINT_DURATION={print_duration}
+  {% if printer.save_variables.variables.was_interrupted %}
+    {% set file_position = printer.save_variables.variables.file_position %}
+    {% set absolute_extrude = printer.save_variables.variables.absolute_extrude %}
+    {% set e_pos = printer.save_variables.variables.e_pos %}
+    {% set x_pos = printer.save_variables.variables.x_pos %}
+    {% set y_pos = printer.save_variables.variables.y_pos %}
+    {% set z_pos = printer.save_variables.variables.z_pos %}
+    {% set last_file = params.GCODE_FILE|default(printer.save_variables.variables.sd_filename)|string %}
+    {% set print_duration = printer.save_variables.variables.print_duration %}
+    {% set filament_used = printer.save_variables.variables.filament_used %}
+    {% set nozzle_temp = printer.save_variables.variables.nozzle_temp %}
+    {% set bed_temp = printer.save_variables.variables.bed_temp %}
+    {% set bed_temp_out = printer.save_variables.variables.bed_temp_out %}
+    {% set chamber_fan_speed = printer.save_variables.variables.chamber_fan_speed %}  
+    {% set max_velocity = printer.save_variables.variables.max_velocity %}
+    {% set max_accel = printer.save_variables.variables.max_accel %}
+    {% set minimum_cruise_ratio = printer.save_variables.variables.minimum_cruise_ratio %}
+    {% set square_corner_velocity = printer.save_variables.variables.square_corner_velocity %}
+    {% set speed_factor = printer.save_variables.variables.speed_factor %}
+    {% set extrude_factor = printer.save_variables.variables.extrude_factor %}
+    {% set fan_speed = printer.save_variables.variables.fan_speed %}
+    G28
+    _SCREEN_LED_ON R=1 O=1 W=0
+    M104 S{nozzle_temp}
+    M140 S{bed_temp} A1 B0
+    SET_HEATER_TEMPERATURE HEATER=heater_bed_2 TARGET={bed_temp_out} WAIT=0
+    M109 S{nozzle_temp}
+    M190 S{bed_temp} A1 B0
+    SET_HEATER_TEMPERATURE HEATER=heater_bed_2 TARGET={bed_temp_out} WAIT=1
+    _SCREEN_LED_ON R=0 O=1 W=1
+    SET_FAN_SPEED FAN=chamber_fan SPEED={chamber_fan_speed}
+    G90
+    G92 E{e_pos}
+    {% if absolute_extrude %}
+      M82
+    {% else %}
+      M83
+    {% endif%}
+    G1 X{x_pos} Y{y_pos} Z{z_pos} E1 F2000
+    SET_VELOCITY_LIMIT VELOCITY={max_velocity} ACCEL={max_accel} MINIMUM_CRUISE_RATIO={minimum_cruise_ratio} SQUARE_CORNER_VELOCITY={square_corner_velocity}
+    M220 S{speed_factor * 100}
+    M221 S{extrude_factor * 100}
+    {% set fan_speed = fan_speed * 255 / 0.90 %}
+    M106 S{fan_speed}
+    POWER_LOSS_RESTART_PRINT FILENAME='{last_file}' FILEPOSITION={file_position} PRINT_DURATION={print_duration} FILAMENT_USED={filament_used}
+  {% else %}
+    RESPOND MSG="No previous state saved!"
+  {% endif%}
 
+[gcode_macro _SAVE_POWER_LOSS_PARAMS]
+description: Save parameters for Power Loss Recovery
+gcode:
+    SAVE_VARIABLE VARIABLE=sd_filename VALUE='"{printer.virtual_sdcard.file_path|string}"'
+    SAVE_VARIABLE VARIABLE=file_position VALUE={printer.virtual_sdcard.file_position}
+    SAVE_VARIABLE VARIABLE=absolute_extrude VALUE={printer.gcode_move.absolute_extrude}
+    SAVE_VARIABLE VARIABLE=e_pos VALUE={printer.gcode_move.gcode_position.e}
+    SAVE_VARIABLE VARIABLE=x_pos VALUE={printer.gcode_move.gcode_position.x}
+    SAVE_VARIABLE VARIABLE=y_pos VALUE={printer.gcode_move.gcode_position.y}
+    SAVE_VARIABLE VARIABLE=z_pos VALUE={printer.gcode_move.gcode_position.z}
+    SAVE_VARIABLE VARIABLE=speed_factor VALUE={printer.gcode_move.speed_factor}
+    SAVE_VARIABLE VARIABLE=extrude_factor VALUE={printer.gcode_move.extrude_factor}
+    SAVE_VARIABLE VARIABLE=print_duration VALUE={printer.print_stats.print_duration}
+    SAVE_VARIABLE VARIABLE=filament_used VALUE={printer.print_stats.filament_used}
+    SAVE_VARIABLE VARIABLE=fan_speed VALUE={printer.fan.speed|float}
+    SAVE_VARIABLE VARIABLE=nozzle_temp VALUE={printer.extruder.target|float}
+    SAVE_VARIABLE VARIABLE=bed_temp VALUE={printer.heater_bed.target|float}
+    SAVE_VARIABLE VARIABLE=bed_temp_out VALUE={printer["heater_generic heater_bed_2"].target|float}
+    SAVE_VARIABLE VARIABLE=chamber_fan_speed VALUE={printer["fan_generic chamber_fan"].speed|float}
+    SAVE_VARIABLE VARIABLE=max_velocity VALUE={printer.toolhead.max_velocity}
+    SAVE_VARIABLE VARIABLE=max_accel VALUE={printer.toolhead.max_accel}
+    SAVE_VARIABLE VARIABLE=minimum_cruise_ratio VALUE={printer.toolhead.minimum_cruise_ratio}
+    SAVE_VARIABLE VARIABLE=square_corner_velocity VALUE={printer.toolhead.square_corner_velocity}
+    SAVE_VARIABLE VARIABLE=was_interrupted VALUE=True
+
+[gcode_macro _CLEAR_POWER_LOSS_PARAMS]
+description: Clear parameters for Power Loss Recovery
+gcode:
+    SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
+    SAVE_VARIABLE VARIABLE=file_position VALUE=0
+    SAVE_VARIABLE VARIABLE=absolute_extrude VALUE=False
+    SAVE_VARIABLE VARIABLE=e_pos VALUE=0.0
+    SAVE_VARIABLE VARIABLE=x_pos VALUE=0.0
+    SAVE_VARIABLE VARIABLE=y_pos VALUE=0.0
+    SAVE_VARIABLE VARIABLE=z_pos VALUE=0.0
+    SAVE_VARIABLE VARIABLE=speed_factor VALUE=1.0
+    SAVE_VARIABLE VARIABLE=extrude_factor VALUE=1.0
+    SAVE_VARIABLE VARIABLE=print_duration VALUE=0.0
+    SAVE_VARIABLE VARIABLE=filament_used VALUE=0.0
+    SAVE_VARIABLE VARIABLE=fan_speed VALUE=0.0
+    SAVE_VARIABLE VARIABLE=nozzle_temp VALUE=0
+    SAVE_VARIABLE VARIABLE=bed_temp VALUE=0
+    SAVE_VARIABLE VARIABLE=bed_temp_out VALUE=0
+    SAVE_VARIABLE VARIABLE=chamber_fan_speed VALUE=0.0
+    SAVE_VARIABLE VARIABLE=max_velocity VALUE={printer.toolhead.max_velocity}
+    SAVE_VARIABLE VARIABLE=max_accel VALUE={printer.toolhead.max_accel}
+    SAVE_VARIABLE VARIABLE=minimum_cruise_ratio VALUE={printer.toolhead.minimum_cruise_ratio}
+    SAVE_VARIABLE VARIABLE=square_corner_velocity VALUE={printer.toolhead.square_corner_velocity}
 
 ##################################################
 # Gcode Offsets Management
@@ -1438,6 +1475,7 @@ gcode:
     RESPOND MSG="Resonances Calibration done!"
   {% endif %}
   {% if printer.save_variables.variables.was_interrupted %}
+    G4 P5000
     RESPOND TYPE=command MSG="action:prompt_begin Power Loss Recovery"
     RESPOND TYPE=command MSG="action:prompt_text A power loss has occurred!"
     RESPOND TYPE=command MSG="action:prompt_text Do you want to resume current print?"
@@ -1445,13 +1483,12 @@ gcode:
     RESPOND TYPE=command MSG="action:prompt_footer_button RESUME PRINT|RESUME_PRINT_AFTER_PLR|primary"
     RESPOND TYPE=command MSG="action:prompt_show"
   {% endif %}
-  SAVE_VARIABLE VARIABLE=plr_flag VALUE=False
 
 [gcode_macro _CANCEL_PLR]
 description: Cancel Power Loss Recovery
 gcode:
   RESPOND TYPE=command MSG=action:prompt_end
-  SAVE_VARIABLE VARIABLE=was_interrupted VALUE=False
+  _CLEAR_POWER_LOSS_PARAMS
 
 [gcode_shell_command Screenshot]
 command: bash /home/pi/flsun-os/macros/screenshot.sh

--- a/config/Stock (without Silent Kit)/macros.cfg
+++ b/config/Stock (without Silent Kit)/macros.cfg
@@ -695,7 +695,7 @@ gcode:
 [gcode_macro CALIBRATION_PID_HOTEND]
 description: Start Hotend PID Calibration
 gcode:
-  {% set HOTEND_TEMP=params.HOTEND_TEMP|default(350)|float %}
+  {% set HOTEND_TEMP=params.HOTEND_TEMP|default(250)|float %}
   {% if printer.idle_timeout.state == "Printing" %}
     RESPOND TYPE=error MSG="This macro cannot be used while printing!"
   {% else %}

--- a/config/Stock (without Silent Kit)/printer.cfg
+++ b/config/Stock (without Silent Kit)/printer.cfg
@@ -239,7 +239,7 @@ max_power: 0.90
 [heater_fan heat_sink_fan]
 pin: PA2
 heater_temp: 50.0
-shutdown_speed: 0
+shutdown_speed: 1
 
 [heater_fan motherboard_fan]
 pin: PB5
@@ -256,7 +256,7 @@ pin: PB4
 [heater_fan drying_box_fan]
 pin: PA8
 heater: drying_box
-shutdown_speed: 0
+shutdown_speed: 1
 
 [temperature_sensor _drying_box_temp]
 sensor_type: temperature_host
@@ -429,39 +429,27 @@ switch_pin: PD3
 event_delay: 0.01
 pause_delay: 0.01
 runout_gcode:
-  RESPOND TYPE=error MSG="Power loss detected!"
   _SCREEN_LED_ON R=1 O=0 W=0
   {% if printer.print_stats.state == "printing" %}
-    {% set file_position = printer.virtual_sdcard.file_position %}
-    SAVE_VARIABLE VARIABLE=file_position VALUE={file_position}
-    {% set e_pos = printer.gcode_move.gcode_position.e %}
-    SAVE_VARIABLE VARIABLE=e_pos VALUE={e_pos}
-    {% set x_pos = printer.gcode_move.gcode_position.x %}
-    SAVE_VARIABLE VARIABLE=x_pos VALUE={x_pos}
-    {% set y_pos = printer.gcode_move.gcode_position.y %}
-    SAVE_VARIABLE VARIABLE=y_pos VALUE={y_pos}
-    {% set z_pos = printer.gcode_move.gcode_position.z %}
-    SAVE_VARIABLE VARIABLE=z_pos VALUE={z_pos}
-    {% set print_duration = printer.print_stats.print_duration %}
-    SAVE_VARIABLE VARIABLE=print_duration VALUE={print_duration}
-    {% set fan_speed = printer.fan.speed|float %}
-    SAVE_VARIABLE VARIABLE=fan_speed VALUE={fan_speed}
-    {% set nozzle_temp = printer.extruder.target|float %}
-    SAVE_VARIABLE VARIABLE=nozzle_temp VALUE={nozzle_temp}
-    {% set bed_temp = printer.heater_bed.target|float %}
-    SAVE_VARIABLE VARIABLE=bed_temp VALUE={bed_temp}
-    SAVE_VARIABLE VARIABLE=was_interrupted VALUE=True
+    _SAVE_POWER_LOSS_PARAMS
+    FAN_STOP
+    TURN_OFF_HEATERS
+    SET_FAN_SPEED FAN=chamber_fan SPEED=0
+    _CHAMBER_LED_OFF
+    RESPOND TYPE=error MSG="Power loss detected!"
+    M400
+    SET_STEPPER_ENABLE STEPPER=extruder ENABLE=0
     STEPPER_STOP
     _SHUTDOWN
     G4 P5000
   {% endif %}
 insert_gcode:
   {% if printer.print_stats.state != "printing" %}
-    RESPOND TYPE=error MSG="Power loss detected! Shutting down."
     _SCREEN_LED_ON R=1 O=0 W=0
+    RESPOND TYPE=error MSG="Power loss detected! Shutting down."
+    FAN_STOP
     TURN_OFF_HEATERS
     SET_FAN_SPEED FAN=chamber_fan SPEED=0
-    M106.1 S0 
     _SHUTDOWN
     G4 P5000
   {% endif %}

--- a/config/Stock (without Silent Kit)/printer.cfg
+++ b/config/Stock (without Silent Kit)/printer.cfg
@@ -148,7 +148,7 @@ spi_software_sclk_pin: PA6
 spi_software_mosi_pin: PA5
 spi_software_miso_pin: PC4
 sense_resistor: 0.0375
-run_current: 1.2
+run_current: 0.8
 interpolate: True
 stealthchop_threshold: 0
 

--- a/klippy/extras/print_stats.py
+++ b/klippy/extras/print_stats.py
@@ -92,7 +92,7 @@ class PrintStats:
         self.init_duration = 0.
         self.info_total_layer = None
         self.info_current_layer = None
-        self.duration = 0
+        self.duration = 0 # FLSUN Changes
     def get_status(self, eventtime):
         time_paused = self.prev_pause_duration
         if self.print_start_time is not None:

--- a/klippy/extras/print_stats.py
+++ b/klippy/extras/print_stats.py
@@ -92,6 +92,7 @@ class PrintStats:
         self.init_duration = 0.
         self.info_total_layer = None
         self.info_current_layer = None
+        self.duration = 0
     def get_status(self, eventtime):
         time_paused = self.prev_pause_duration
         if self.print_start_time is not None:
@@ -103,10 +104,7 @@ class PrintStats:
                 self._update_filament_usage(eventtime)
             # Start FLSUN Changes
             #self.total_duration = eventtime - self.print_start_time
-            if(self.duration == 0):
-                self.total_duration = eventtime - self.print_start_time
-            else:
-                self.total_duration = eventtime - self.print_start_time + self.duration
+            self.total_duration = eventtime - self.print_start_time + self.duration
             # End FLSUN Changes
             if self.filament_used < 0.0000001:
                 # Track duration prior to extrusion
@@ -125,6 +123,9 @@ class PrintStats:
     # Start FLSUN Changes
     def modify_print_time(self, time):
         self.duration = time
+
+    def set_filament_used(self, filament_used):
+        self.filament_used = filament_used
     # End FLSUN Changes
 
 def load_config(config):

--- a/klippy/extras/virtual_sdcard.py
+++ b/klippy/extras/virtual_sdcard.py
@@ -184,12 +184,12 @@ class VirtualSD:
         filename = gcmd.get("FILENAME")
         fileposition = gcmd.get("FILEPOSITION")
         fname = os.path.basename(filename)
-        print_duration = gcmd.get("PRINT_DURATION")
-        self.print_stats.modify_print_time(float(print_duration))
-        self._load_file(gcmd, fname, fileposition, check_subdirs=True)      
+        gcmd_print_duration = gcmd.get("PRINT_DURATION", 0)
+        gcmd_filament_used = gcmd.get("FILAMENT_USED", 0.)
+        self._load_file(gcmd, fname, fileposition, check_subdirs=True, print_duration=gcmd_print_duration, filament_used=gcmd_filament_used)      
         self.do_resume()
     #def _load_file(self, gcmd, filename, check_subdirs=False):
-    def _load_file(self, gcmd, filename, fileposition=0, check_subdirs=False):
+    def _load_file(self, gcmd, filename, fileposition=0, check_subdirs=False, print_duration=0, filament_used=0.):
     # End FLSUN Changes
         files = self.get_file_list(check_subdirs)
         flist = [f[0] for f in files]
@@ -220,6 +220,8 @@ class VirtualSD:
             self.gcode.run_script_from_command("G28")
             self.gcode.run_script_from_command("_START_PRINT")
         else:
+            self.print_stats.set_filament_used(float(filament_used))
+            self.print_stats.modify_print_time(float(print_duration))
             self.gcode.run_script_from_command("_START_PRINT_RESUME")
         # End FLSUN Changes
     def cmd_M24(self, gcmd):


### PR DESCRIPTION
PLR is now remembering all print parameters ( filament used, speed and extrude factors, last velocity parameters, chamber fan speed, and more  ) and waiting for the current move queue to finish. That means if you restart the print, it will continue exactly from the position where it ended.

Other changes: 
- _START_PRINT macro is using parameters from config file inc stepper current, which was 1.2Amps so I changed it to recomended 0.8Amps
- default temp for PID hotend calibration changed to 250 from 350
- RESUME macro is now shutting down the fan for heating back