### PR TITLE
Update maximum fan power for S1 Pro.

### DIFF
--- a/config/FLSUN S1/Configurations/fan-silent-kit.cfg
+++ b/config/FLSUN S1/Configurations/fan-silent-kit.cfg
@@ -16,7 +16,7 @@
 [fan]
 pin: PC7
 cycle_time: 0.0001
-max_power: 0.5
+max_power: 0.55
 
 [heater_fan heat_sink_fan]
 pin: PA2


### PR DESCRIPTION
S1 Pro stock firmware 1.0.1.10 uses 0.55 maximum fan power.
