### PR TITLE
Fix casing in `moonraker.conf`.

### DIFF
--- a/config/FLSUN S1/moonraker.conf
+++ b/config/FLSUN S1/moonraker.conf
@@ -103,7 +103,7 @@ requirements: scripts/KlipperScreen-requirements.txt
 system_dependencies: scripts/system-dependencies.json
 managed_services: KlipperScreen
 
-[update_manager Mainsail]
+[update_manager mainsail]
 type: web
 channel: beta
 repo: mainsail-crew/mainsail


### PR DESCRIPTION
When switching to Fluidd and reinstalling Mainsail afterwards using `kiauh`, reinstalling will add a `[update_manager mainsail]` entry, despite `[update_manager Mainsail]` already existing.