### PR TITLE
Don't show drying box units twice.

### DIFF
--- a/config/FLSUN S1/moonraker.conf
+++ b/config/FLSUN S1/moonraker.conf
@@ -50,13 +50,13 @@ cors_domains:
 [sensor_custom Drying_Box]
 type: jsonfile
 path: /dev/shm/drying_box.json
-parameter_temperature_(°C):
+parameter_temperature:
   json_path=result/drybox/temperature
   units=°C
-parameter_humidity_(%_RH):
+parameter_relative_humidity:
   json_path=result/drybox/humidity
   units=%
-parameter_spool_weight_(%):
+parameter_spool_weight:
   json_path=result/drybox/weight
   units=%
 


### PR DESCRIPTION
Remove units from parameter names, since the unit is already shown after the value itself.